### PR TITLE
Datatype error fix

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -1450,7 +1450,7 @@ def calcEarthSunDist(t):
     hr = t.hour
     minute = t.minute
     sec = t.second
-    ut = hr + (minute/60) + (sec/3600)
+    ut = hr + (minute/60.) + (sec/3600.)
     #print ut
 
     if month <= 2:

--- a/tests/unit_test_ortho_functions.py
+++ b/tests/unit_test_ortho_functions.py
@@ -68,7 +68,7 @@ class TestMetadata(unittest.TestCase):
                     self.assertGreater(calib_dict['BAND_P'][1],-0.029)
                     self.assertLess(calib_dict['BAND_P'][1],-0.0098)
                 if 'BAND_B' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_B'][1],-0.1306)
+                    self.assertGreater(calib_dict['BAND_B'][1],-0.1305)
                     self.assertLess(calib_dict['BAND_B'][1],-0.0085)
                 if 'BAND_B' in calib_dict and 'BAND_G' in calib_dict: ### check bands are not equal
                     self.assertNotEqual(calib_dict['BAND_B'][0],calib_dict['BAND_G'][0])


### PR DESCRIPTION
When calculating calibration parameters in ortho_functions.py, the decimal hours ("ut") variable is returned as an int, but should instead be returned as a float. This pull fixes that issue, and updates the testing threshold set in the unit tests to account for the new variable. 

Passed unit and functional tests. 
Tested in Python 2.7.12 and Python 3.6.5. 
