### PR TITLE
Python 3 compatibility

### DIFF
--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -146,7 +146,7 @@ class ImageInfo:
                     if 'BAND_G' in item:
                         self.tdi = int(item[7:])
                 except ValueError:
-                    logger.error("cannot parse TDI field for {}: {}".format(self.scene_id, tdi_str))
+                    logger.error("cannot parse TDI field for %s: %s", self.scene_id, tdi_str)
         
         i = feat.GetFieldIndex("ACQ_TIME")
         if i != -1:
@@ -224,7 +224,7 @@ class ImageInfo:
             self.ys = [uly, ury, lry, lly]
 
         else:
-            logger.warning("Cannot open image: {}".format(self.srcfp))
+            logger.warning("Cannot open image: %s", self.srcfp)
             self.xsize = None
             self.ysize = None
             self.proj = None
@@ -315,7 +315,7 @@ class ImageInfo:
                 break
         
         if not metapath:
-            logger.debug("No metadata found for {}".format(self.srcfp))
+            logger.debug("No metadata found for %s", self.srcfp)
         
         else:
             metad = None
@@ -325,13 +325,13 @@ class ImageInfo:
                 try:
                     metad = ET.parse(metapath)
                 except ET.ParseError as err:
-                    logger.debug("ERROR parsing metadata: {}, {}".format(err, metapath))
+                    logger.debug("ERROR parsing metadata: %s, %s", err, metapath)
             
             else:
                 try:
                     metad = utils.getGEMetadataAsXml(metapath)
                 except Exception as err:
-                    logger.debug("ERROR parsing metadata: {}, {}".format(err, metapath))
+                    logger.debug("ERROR parsing metadata: %s, %s", err, metapath)
                 #### Write IK01 code 
         
             if metad is not None:
@@ -371,7 +371,7 @@ class ImageInfo:
                                 vallist.append(val)
                                 
                             except Exception as e:
-                                logger.debug("Error reading metadata values: {}, {}".format(metapath, e))
+                                logger.debug("Error reading metadata values: %s, %s", metapath, e)
                                 
                     if dTags[tag] == 'tdi' and len(taglist) > 1:    
                         #### use pan or green band TDI for exposure calculation
@@ -385,8 +385,8 @@ class ImageInfo:
                             dAttribs['tdi'] = vallist[3]
                         else:
                             logger.debug("Unexpected number of TDI values and band count ( TDI: expected 1, 4, 5, or 8 "
-                                         "- found {} ; Band cound, expected 1, 4, or 8 - found {}) {}".format(
-                                len(vallist), self.bands, metapath))
+                                         "- found %i ; Band count, expected 1, 4, or 8 - found %i) %s", len(vallist),
+                                         self.bands, metapath)
                     
                     elif dTags[tag] == 'sensor' and len(taglist) > 1:
                         val = vallist[0]
@@ -397,7 +397,7 @@ class ImageInfo:
                         dAttribs[dTags[tag]] = val
                         
                     elif len(taglist) > 1:
-                        logger.debug("Unexpected number of {} values ({}), {}".format(tag, len(taglist), metapath))
+                        logger.debug("Unexpected number of %s values (%i), %s", tag, len(taglist), metapath)
                 
                 self.sataz = float(dAttribs["sataz"])
                 self.satel = float(dAttribs["satel"])
@@ -419,7 +419,7 @@ class ImageInfo:
                         try:
                             self.acqdate = datetime.strptime(dAttribs["date"], "%Y-%m-%d %H:%M GMT")
                         except ValueError:
-                            logger.error("Cannot parse date string {} from {}".format(dAttribs['date'], metapath))
+                            logger.error("Cannot parse date string %s from %s", dAttribs['date'], metapath)
 
 
     def getScore(self, params):
@@ -440,8 +440,8 @@ class ImageInfo:
         status = [val is None for val in required_attribs]
         
         if sum(status) != 0:
-            logger.error("Cannot determine score for image {0}:\n  Sun elev\t{1}\n  Off nadir\t{2}\n  Cloudcover\t{3}\n"
-                         "  Sensor\t{4}".format(self.srcfn, self.sunel, self.ona, self.cloudcover, self.sensor))
+            logger.error("Cannot determine score for image %s:\n  Sun elev\t%s\n  Off nadir\t%s\n  Cloudcover\t%s\n"
+                         "  Sensor\t%s", self.srcfn, self.sunel, self.ona, self.cloudcover, self.sensor)
             score = -1
         
         else:
@@ -455,7 +455,7 @@ class ImageInfo:
             #### Test if TDI is needed, get exposure factor
             if params.useExposure is True:
                 if self.tdi is None:
-                    logger.error("Cannot get tdi for image to determine exposure settings: {0}".format(self.srcfp))
+                    logger.error("Cannot get tdi for image to determine exposure settings: %s", self.srcfp)
                     self.exposure_factor = None
                 else:
                     exfact = self.tdi * self.sunel
@@ -480,19 +480,19 @@ class ImageInfo:
                     if params.bands == 1:
                         if self.sensor in pan_exposure_thresholds:
                             if exfact > pan_exposure_thresholds[self.sensor]:
-                                logger.debug("Image overexposed: {0} --> {1}".format(self.srcfp, exfact))
+                                logger.debug("Image overexposed: %s --> %i", self.srcfp, exfact)
                                 score = -1
                     
                     else:
                         if self.sensor in multi_exposure_thresholds:
                             if exfact > multi_exposure_thresholds[self.sensor]:
-                                logger.debug("Image overexposed: {0} --> {1}".format(self.srcfp, exfact))
+                                logger.debug("Image overexposed: %s --> %i", self.srcfp, exfact)
                                 score = -1
             
             #### Test if acqdate if needed, get date difference
             if params.m != 0:
                 if self.acqdate is None:
-                    logger.error("Cannot get acqdate for image to determine date-based score: {0}".format(self.srcfn))
+                    logger.error("Cannot get acqdate for image to determine date-based score: %s", self.srcfn)
                     self.date_diff = -9999
                     
                 else:
@@ -519,7 +519,7 @@ class ImageInfo:
 
             if params.y != 0:
                 if self.acqdate is None:
-                    logger.error("Cannot get acqdate for image to determine date-based score: {0}".format(self.srcfn))
+                    logger.error("Cannot get acqdate for image to determine date-based score: %s", self.srcfn)
                     self.year_diff = -9999
 
                 else:
@@ -549,12 +549,12 @@ class ImageInfo:
                 self.cloudcover = params.max_cc
             
             if self.cloudcover > params.max_cc:
-                logger.debug("Image too cloudy (>{0}): {1} --> {2}".format(params.max_cc, self.srcfp, self.cloudcover))
+                logger.debug("Image too cloudy (>%s): %s --> %f", params.max_cc, self.srcfp, self.cloudcover)
                 score = -1
             
             #### Handle ridiculously low sun el values, these images will result is spurious TOA values
             if self.sunel < 2:
-                logger.debug("Sun elevation too low (<2 degrees): {0} --> {1}".format(self.srcfp, self.sunel))
+                logger.debug("Sun elevation too low (<2 degrees): %s --> %f", self.srcfp, self.sunel)
                 score = -1
                         
             if not score == -1:
@@ -588,15 +588,15 @@ class ImageInfo:
                 # get nodata value (default to zero)
                 band_nodata = band.GetNoDataValue()
                 if band_nodata is None:
-                    logger.info("Defaulting band {} nodata value to zero".format(bandnum))
+                    logger.info("Defaulting band %i nodata value to zero", bandnum)
                     band_nodata = 0.0
 
                 # read band as a numpy array
-                logger.debug("Reading band {} ".format(bandnum))
+                logger.debug("Reading band %i ", bandnum)
                 band_array = band.ReadAsArray(0, 0, nx, ny)
 
                 # generate mask for nodata
-                logger.debug("Calculating band {} no data mask".format(bandnum))
+                logger.debug("Calculating band %i no data mask", bandnum)
                 band_nodata_mask = (band_array == band_nodata)
                 band_valid = band_array[~band_nodata_mask]
                 self.datapixelcount_dct[bandnum] = band_valid.size
@@ -605,28 +605,27 @@ class ImageInfo:
                 stats = numpy.array([band_nodata, band_nodata, band_nodata, band_nodata], numpy.float64)
                 band_median = numpy.float64(band_nodata)
                 if band_valid.size == 0: 
-                    logger.warning("Band {} contains no valid data".format(bandnum))
+                    logger.warning("Band %i contains no valid data", bandnum)
                 
                 ## calc stats  
                 else:
                     if get_stats:
-                        logger.debug("Calculating band {} min".format(bandnum))
+                        logger.debug("Calculating band %i min", bandnum)
                         band_min = numpy.amin(band_valid)
-                        logger.debug("Calculating band {} max".format(bandnum))
+                        logger.debug("Calculating band %i max", bandnum)
                         band_max = numpy.amax(band_valid)
-                        logger.debug("Calculating band {} mean".format(bandnum))
+                        logger.debug("Calculating band %i mean", bandnum)
                         band_mean = numpy.mean(band_valid,dtype=numpy.float64)
-                        logger.debug("Calculating band {} stdev".format(bandnum))
+                        logger.debug("Calculating band %i stdev", bandnum)
                         band_std = numpy.std(band_valid,dtype=numpy.float64)
                         stats = numpy.array([band_min, band_max, band_mean, band_std], numpy.float64)
-                        logger.info("band {} min {}, max {}, mean {}, stdev {}".format(
-                            bandnum, band_min, band_max, band_mean, band_std
-                        ))
+                        logger.info("band %i min %f, max %f, mean %f, stdev %f", bandnum, band_min, band_max,
+                                    band_mean, band_std)
                                
                     if get_median:
-                        logger.debug("Calculating band {} median".format(bandnum))
+                        logger.debug("Calculating band %i median", bandnum)
                         band_median = numpy.float64(numpy.median(band_valid))
-                        logger.info("band {} median {}".format(bandnum, band_median))
+                        logger.info("band %i median %f", bandnum, band_median)
                 
                 self.median[bandnum] = band_median
                 self.stat_dct[bandnum] = stats
@@ -638,7 +637,7 @@ class ImageInfo:
             ds = None
 
         else:
-            logger.warning("Cannot open image: {}".format(self.srcfp))
+            logger.warning("Cannot open image: %s", self.srcfp)
   
             
     def set_raster_median(self, median):
@@ -731,8 +730,8 @@ class DemInfo:
         status2 = [val is None for val in required_attribs2]
 
         if sum(status1) != 0 and sum(status2) != 0:
-            logger.error("Cannot determine score for image {0}:\n  Sun elev\t{1}\n  Cloudcover\t{2}\n  Sensor\t{3}\n  "
-                         "Density\t{4}".format(self.pairname, self.sunel, self.cloudcover, self.sensor, self.density))
+            logger.error("Cannot determine score for image %s:\n  Sun elev\t%f\n  Cloudcover\t$f\n  Sensor\t%s\n  "
+                         "Density\t%f", self.pairname, self.sunel, self.cloudcover, self.sensor, self.density)
             score = -1
             
         elif self.sensor == 'QB02':
@@ -743,7 +742,7 @@ class DemInfo:
             #### Test if acqdate if needed, get date difference
             if target_date:
                 if self.acqdate is None:
-                    logger.error("Cannot get acqdate for image to determine date-based score: {0}".format(self.srcfn))
+                    logger.error("Cannot get acqdate for image to determine date-based score: %s", self.srcfn)
                     self.date_diff = -9999
                     
                 else:
@@ -775,13 +774,12 @@ class DemInfo:
                     self.cloudcover = 0.5
             
                 if self.cloudcover > 0.2:
-                    logger.debug("Stereopair too cloudy (>20 percent): {0} --> {1}".format(self.pairname,
-                                                                                           self.cloudcover))
+                    logger.debug("Stereopair too cloudy (>20 percent): %s --> %f", self.pairname, self.cloudcover)
                     score = -1
             
             #### Handle ridiculously low sun el values
             if self.sunel and self.sunel < 1:
-                logger.debug("Sun elevation too low (<1 degrees): {0} --> {1}".format(self.pairname, self.sunel))
+                logger.debug("Sun elevation too low (<1 degrees): %s --> %f", self.pairname, self.sunel)
                 score = -1
                         
             if not score == -1:
@@ -859,8 +857,8 @@ class DGInfo:
         status1 = [val is None for val in required_attribs1]
 
         if sum(status1) != 0:
-            logger.error("Cannot determine score for image {0}:\n  Sun elev\t{1}\n  Cloudcover\t{2}\n  Sensor\t{3}".
-                         format(self.pairname, self.sunel, self.cloudcover, self.sensor))
+            logger.error("Cannot determine score for image %s:\n  Sun elev\t%f\n  Cloudcover\t%f\n  Sensor\t%s",
+                         self.pairname, self.sunel, self.cloudcover, self.sensor)
             score = -1
         
         else:
@@ -868,14 +866,14 @@ class DGInfo:
             #### Test if acqdate if needed, get date difference
             if target_date:
                 if self.acqdate is None:
-                    logger.error("Cannot get acqdate for image to determine date-based score: {0}".format(self.srcfn))
+                    logger.error("Cannot get acqdate for image to determine date-based score: %s", self.srcfn)
                     self.date_diff = -9999
                     
                 else:
                     #### Find nearest year for target day
                     tdeltas = []
                     target_month, target_day = target_date[0]
-                    for y in list(range(self.acqdate.year-1, self.acqdate.year+2)):
+                    for y in list(range(self.acqdate.year - 1, self.acqdate.year + 2)):
                         tdeltas.append(abs((datetime(y, target_month, target_day) - self.acqdate).days))
                     
                     self.date_diff = min(tdeltas)
@@ -899,12 +897,12 @@ class DGInfo:
                     self.cloudcover = 0.5
             
                 if self.cloudcover > 0.2:
-                    logger.debug("Catid too cloudy (>20 percent): {0} --> {1}".format(self.pairname, self.cloudcover))
+                    logger.debug("Catid too cloudy (>20 percent): %s --> %f", self.pairname, self.cloudcover)
                     score = -1
             
             #### Handle ridiculously low sun el values
             if self.sunel and self.sunel < 1:
-                logger.debug("Sun elevation too low (<1 degrees): {0} --> {1}".format(self.pairname, self.sunel))
+                logger.debug("Sun elevation too low (<1 degrees): %s --> %f", self.pairname, self.sunel)
                 score = -1
                         
             if not score == -1:
@@ -946,13 +944,13 @@ def determine_contributors(imginfo_list, tile_geom, contribution_threshold):
     for iinfo in imginfo_list:
         diff = iinfo.geom.Difference(union_geom)
         if diff is None:
-            logger.info("Function Error: {}".format(iinfo.srcfp))
+            logger.info("Function Error: %s", iinfo.srcfp)
         elif diff.IsEmpty():
-            logger.debug("Non-contributing image: {}".format(iinfo.srcfp))
+            logger.debug("Non-contributing image: %s", iinfo.srcfp)
         else:
             ## test if contributing area is within tile extent
             if not diff.Intersects(tile_geom):
-                logger.debug("Non-contributing image: {}".format(iinfo.srcfp))
+                logger.debug("Non-contributing image: %s", iinfo.srcfp)
             else:
                 contrib_geom = diff.Intersection(tile_geom)
                 
@@ -961,7 +959,7 @@ def determine_contributors(imginfo_list, tile_geom, contribution_threshold):
                     union_geom = union_geom.Union(iinfo.geom)
                     contribs.append((iinfo, contrib_geom))
                 else:
-                    logger.debug("Image below minimum area threshold: {}".format(iinfo.srcfp))
+                    logger.debug("Image below minimum area threshold: %s", iinfo.srcfp)
                     area_threshold_images.append(iinfo)
                     
     # after first round, check if any of the images below the min area threshold fill a gap
@@ -969,15 +967,14 @@ def determine_contributors(imginfo_list, tile_geom, contribution_threshold):
         for iinfo in area_threshold_images:
             diff = iinfo.geom.Difference(union_geom)
             if diff is None:
-                logger.info("Function Error: {}".format(iinfo.srcfp))
+                logger.info("Function Error: %s", iinfo.srcfp)
             elif not diff.IsEmpty():
                 ## test if contributing area is within tile extent
                 if diff.Intersects(tile_geom):
                     contrib_geom = diff.Intersection(tile_geom)
                     union_geom = union_geom.Union(iinfo.geom)
                     contribs.append((iinfo, contrib_geom))
-                    logger.debug("Adding image with contribution area below threshold to fill a gap: {}".
-                                 format(iinfo.srcfp))
+                    logger.debug("Adding image with contribution area below threshold to fill a gap: %s", iinfo.srcfp)
     
     # reverse list so highest score is last
     contribs.reverse()
@@ -996,14 +993,14 @@ def filterMatchingImages(imginfo_list, params):
         rp.ImportFromWkt(params.proj)
         if p.IsSame(rp) is False:
             isSame = False
-            logger.debug("Image projection differs from mosaic params: {}".format(iinfo.srcfp))
+            logger.debug("Image projection differs from mosaic params: %s", iinfo.srcfp)
         if iinfo.bands != params.bands and not (params.force_pan_to_multi is True and iinfo.bands == 1) and not \
                 (params.include_all_ms is True):
             isSame = False
-            logger.debug("Image band count differs from mosaic params: {}".format(iinfo.srcfp))
+            logger.debug("Image band count differs from mosaic params: %s", iinfo.srcfp)
         if iinfo.datatype != params.datatype:
             isSame = False
-            logger.debug("Image datatype differs from mosaic params: {}".format(iinfo.srcfp))
+            logger.debug("Image datatype differs from mosaic params: %s", iinfo.srcfp)
             
         if isSame is True:
             imginfo_list2.append(iinfo)
@@ -1018,9 +1015,9 @@ def filter_images_by_geometry(imginfo_list, params):
             if params.extent_geom.Intersect(iinfo.geom):
                 imginfo_list2.append(iinfo)
             else:
-                logger.debug("Image does not intersect mosaic extent: {}".format(iinfo.srcfn))
+                logger.debug("Image does not intersect mosaic extent: %s", iinfo.srcfn)
         else: # remove from list if no geom
-            logger.debug("Null geometry for image: {} ".format(iinfo.srcfn))
+            logger.debug("Null geometry for image: %s ", iinfo.srcfn)
     return imginfo_list2
 
 

--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -53,8 +53,7 @@ class ImageInfo:
     #"ona":None,
     #"date":None,
     #"tdi":None
-     
-        
+
     def get_attributes_from_record(self, feat, srs):
         
         i = feat.GetFieldIndex("S_FILEPATH")
@@ -106,7 +105,7 @@ class ImageInfo:
         self.xres = None
         self.yres = None
         self.datatype = None
-        
+
         self.sataz = None
         self.satel = None
         self.sunaz = None
@@ -155,8 +154,7 @@ class ImageInfo:
         
         geom = feat.GetGeometryRef()
         self.geom = geom.Clone()
-        
-    
+
     def get_attributes_from_file(self, srcfp):
         self.srcfp = srcfp
         self.srcdir, self.srcfn = os.path.split(srcfp)
@@ -234,7 +232,7 @@ class ImageInfo:
             self.yres = None
 
         ds = None
-        
+
         #### Set unknown attribs to None for now
         self.sataz = None
         self.satel = None
@@ -247,8 +245,8 @@ class ImageInfo:
         self.catid = None
         self.tdi = None
         self.acqdate = None
- 
-   
+
+
     def get_attributes_from_xml(self):
         dAttribs = {
             "cc": None,
@@ -500,8 +498,8 @@ class ImageInfo:
                         tdeltas.append(abs((datetime(y, params.m, params.d) - self.acqdate).days))
 
                     self.date_diff = min(tdeltas)
-            
-            
+
+
                 #### Assign weights
                 ccwt = 30
                 sunelwt = 10
@@ -1182,9 +1180,6 @@ def findVertices(xoff, yoff, xsize, ysize, band, nd):
     
     
 def pl2xy(gtf, band, p, l):
-    
-    cols = band.XSize
-    rows = band.YSize
     
     cellSizeX = gtf[1]
     cellSizeY = -1 * gtf[5]

--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -1,4 +1,4 @@
-import os, string, sys, shutil, math, glob, re, tarfile, logging, platform, argparse, subprocess
+import os, sys, shutil, math, glob, re, tarfile, logging, platform, argparse, subprocess
 from datetime import datetime, timedelta
 from xml.etree import cElementTree as ET
 import gdal, ogr, osr, gdalconst
@@ -1152,7 +1152,7 @@ def GetExactTrimmedGeom(image, step=4, tolerance=1):
                     poly_vts.append("{0:.16f} {1:.16f}".format(pts[0][0], pts[0][1]))
                 
                 if len(poly_vts) > 0:
-                    poly_wkt = 'POLYGON (( {} ))'.format(string.join(poly_vts, ", "))
+                    poly_wkt = 'POLYGON (( {} ))'.format(", ".join(poly_vts))
                     #print(poly_wkt)
                     
                     geom = ogr.CreateGeometryFromWkt(poly_wkt)

--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -1136,7 +1136,7 @@ def GetExactTrimmedGeom(image, step=4, tolerance=1):
                 #print("Pixel Array length: {}".format(len(pixels))
                 
                 for px in pixels:
-                    x,y = pl2xy(gtf, inband, px[0], px[1])
+                    x, y = pl2xy(gtf, inband, px[0], px[1])
                     xs.append(x)
                     ys.append(y)
                     pts.append((x, y))
@@ -1158,7 +1158,7 @@ def GetExactTrimmedGeom(image, step=4, tolerance=1):
                     #### Simplify geom
                     #logger.debug("Simplification tolerance: {0:.10f}".format(tolerance))
                     if geom is not None:
-                        geom2  = geom.Simplify(tolerance)
+                        geom2 = geom.Simplify(tolerance)
         ds = None
 
     return geom2, xs, ys

--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -27,7 +27,6 @@ GTIFF_COMPRESSIONS = ["jpeg95", "lzw"]
 #        self.panfact = dAttribs["panfact"]
 
 
-
 class ImageInfo:
     def __init__(self, src, frmt, srs=None):
         self.frmt = frmt  #image format (IMAGE,RECORD)
@@ -76,7 +75,8 @@ class ImageInfo:
             path = spath
         elif opath and len(opath) > 1:
             path = opath
-        else: path = ""
+        else:
+            path = ""
         
         if r"V:/pgc/agic/private" in path:
             srcfp = path.replace(r"V:/pgc", r'/mnt/agic/storage00')
@@ -167,7 +167,7 @@ class ImageInfo:
             self.ysize = ds.RasterYSize
             self.proj = ds.GetProjectionRef() if ds.GetProjectionRef() != '' else ds.GetGCPProjection()
             self.bands = ds.RasterCount
-            self.nodatavalue = [ds.GetRasterBand(b).GetNoDataValue() for b in list(range(1, self.bands+1))]
+            self.nodatavalue = [ds.GetRasterBand(b).GetNoDataValue() for b in list(range(1, self.bands + 1))]
             self.datatype = ds.GetRasterBand(1).DataType
             self.datatype_readable = gdal.GetDataTypeName(self.datatype)
 
@@ -184,10 +184,9 @@ class ImageInfo:
                 ury = gtf[3] + self.xsize * gtf[4] + 0 * gtf[5]
                 llx = gtf[0] + 0 * gtf[1] + self.ysize * gtf[2]
                 lly = gtf[3] + 0 * gtf[4] + self.ysize * gtf[5]
-                lrx = gtf[0] + self.xsize * gtf[1] + self.ysize* gtf[2]
+                lrx = gtf[0] + self.xsize * gtf[1] + self.ysize * gtf[2]
                 lry = gtf[3] + self.xsize * gtf[4] + self.ysize * gtf[5]
-                
-            
+
             elif num_gcps == 4:
                 
                 gcps = ds.GetGCPs()
@@ -218,7 +217,7 @@ class ImageInfo:
                 self.yres = abs(math.sqrt((ulx - llx) ** 2 + (uly - lly) ** 2) / self.ysize)
                 
             poly_wkt = 'POLYGON (( {0:.12f} {1:.12f}, {2:.12f} {3:.12f}, {4:.12f} {5:.12f}, {6:.12f} {7:.12f}, ' \
-                       '{8:.12f} {9:.12f} ))'.format(ulx, uly, urx, ury, lrx, lry, llx, lly, ulx, uly)
+                       '{0:.12f} {1:.12f} ))'.format(ulx, uly, urx, ury, lrx, lry, llx, lly)
             self.geom = ogr.CreateGeometryFromWkt(poly_wkt)
             self.xs = [ulx, urx, lrx, llx]
             self.ys = [uly, ury, lry, lly]
@@ -421,7 +420,6 @@ class ImageInfo:
                         except ValueError:
                             logger.error("Cannot parse date string %s from %s", dAttribs['date'], metapath)
 
-
     def getScore(self, params):
         
         score = 0
@@ -462,18 +460,18 @@ class ImageInfo:
                     self.exposure_factor = exfact
                     
                     pan_exposure_thresholds = {
-                        "WV01":1400,
-                        "WV02":1400,
-                        "WV03":1400,
-                        "QB02":500,
+                        "WV01": 1400,
+                        "WV02": 1400,
+                        "WV03": 1400,
+                        "QB02": 500,
                         #"GE01":,
                     }
                     
                     multi_exposure_thresholds = {
-                        "WV02":400,
-                        "WV03":400,
-                        "GE01":170,
-                        "QB02":25,
+                        "WV02": 400,
+                        "WV03": 400,
+                        "GE01": 170,
+                        "QB02": 25,
                     }
                     
                     #### Remove images with high exposure settings (tdi_pan (or tdi_grn) * sunel)
@@ -499,8 +497,8 @@ class ImageInfo:
                     #### Find nearest year for target day
                     tdeltas = []
                     for y in list(range(self.acqdate.year - 1, self.acqdate.year + 2)):
-                        tdeltas.append(abs((datetime(y,params.m, params.d) - self.acqdate).days))
-                    
+                        tdeltas.append(abs((datetime(y, params.m, params.d) - self.acqdate).days))
+
                     self.date_diff = min(tdeltas)
             
             
@@ -580,7 +578,7 @@ class ImageInfo:
             ny = ds.RasterYSize
  
             #### get stats and store in dictionaries
-            for bandnum in list(range(1, self.bands+1)):
+            for bandnum in list(range(1, self.bands + 1)):
 
                 # read band
                 band = ds.GetRasterBand(bandnum)
@@ -615,9 +613,9 @@ class ImageInfo:
                         logger.debug("Calculating band %i max", bandnum)
                         band_max = numpy.amax(band_valid)
                         logger.debug("Calculating band %i mean", bandnum)
-                        band_mean = numpy.mean(band_valid,dtype=numpy.float64)
+                        band_mean = numpy.mean(band_valid, dtype=numpy.float64)
                         logger.debug("Calculating band %i stdev", bandnum)
-                        band_std = numpy.std(band_valid,dtype=numpy.float64)
+                        band_std = numpy.std(band_valid, dtype=numpy.float64)
                         stats = numpy.array([band_min, band_max, band_mean, band_std], numpy.float64)
                         logger.info("band %i min %f, max %f, mean %f, stdev %f", bandnum, band_min, band_max,
                                     band_mean, band_std)
@@ -730,7 +728,7 @@ class DemInfo:
         status2 = [val is None for val in required_attribs2]
 
         if sum(status1) != 0 and sum(status2) != 0:
-            logger.error("Cannot determine score for image %s:\n  Sun elev\t%f\n  Cloudcover\t$f\n  Sensor\t%s\n  "
+            logger.error("Cannot determine score for image %s:\n  Sun elev\t%f\n  Cloudcover\t%f\n  Sensor\t%s\n  "
                          "Density\t%f", self.pairname, self.sunel, self.cloudcover, self.sensor, self.density)
             score = -1
             
@@ -766,8 +764,7 @@ class DemInfo:
                 datediffwt = 0
                 densitywt = 100
                 self.date_diff = -9999
-                
-                
+
             #### Handle nonesense or nodata cloud cover values
             if self.cloudcover:
                 if self.cloudcover < 0 or self.cloudcover > 1:
@@ -811,8 +808,7 @@ class DGInfo:
             self.get_attributes_from_record(src, srs)
         else:
             logger.error("Image format must be RECORD")
-        
-        
+
     def get_attributes_from_record(self, feat, srs):
                 
         self.proj = srs.ExportToWkt()
@@ -841,7 +837,6 @@ class DGInfo:
         
         geom = feat.GetGeometryRef()
         self.geom = geom.Clone()
-        
 
     def getScore(self, target_date=None):
         
@@ -889,8 +884,7 @@ class DGInfo:
                 sunelwt = 10
                 datediffwt = 0
                 self.date_diff = -9999
-                
-                
+
             #### Handle nonesense or nodata cloud cover values
             if self.cloudcover:
                 if self.cloudcover < 0 or self.cloudcover > 1:
@@ -1083,9 +1077,9 @@ def getMosaicParameters(iinfo, options):
             params.ytilesize = None
         
     if options.max_cc is not None:
-    	params.max_cc = options.max_cc
+        params.max_cc = options.max_cc
     else:
-    	params.max_cc = 0.5
+        params.max_cc = 0.5
     
     params.force_pan_to_multi = True if params.bands > 1 and options.force_pan_to_multi else False # determine if force pan to multi is applicable and true
 
@@ -1097,6 +1091,7 @@ def getMosaicParameters(iinfo, options):
         params.median_remove = None
 
     return params
+
 
 def GetExactTrimmedGeom(image, step=4, tolerance=1):
     
@@ -1146,7 +1141,7 @@ def GetExactTrimmedGeom(image, step=4, tolerance=1):
                     x,y = pl2xy(gtf, inband, px[0], px[1])
                     xs.append(x)
                     ys.append(y)
-                    pts.append((x,y))
+                    pts.append((x, y))
                     #print(px[0], px[1], x, y)
                 
                 #### create geometry
@@ -1180,10 +1175,10 @@ def findVertices(xoff, yoff, xsize, ysize, band, nd):
         nzmin = nz[0] if nz.size > 0 else 0
         nzmax = nz[-1] if nz.size > 0 else 0
         
-        return(nzbool, nzmin, nzmax)
+        return nzbool, nzmin, nzmax
     
     else:
-        return (False, 0, 0)
+        return False, 0, 0
     
     
 def pl2xy(gtf, band, p, l):

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -525,7 +525,6 @@ def stackIkBands(dstfp, members):
         #print("Merging bands")
         cmd = 'gdalbuildvrt -separate "{}" "{}"'.format(vrt, '" "'.join(members))
 
-        #
         (err, so, se) = taskhandler.exec_cmd(cmd)
         if err == 1:
             rc = 1
@@ -536,7 +535,7 @@ def stackIkBands(dstfp, members):
                                                                                        vrt,
                                                                                        dstfp)
 
-        (err,so,se) = taskhandler.exec_cmd(cmd)
+        (err, so, se) = taskhandler.exec_cmd(cmd)
         if err == 1:
             rc = 1
 
@@ -1448,7 +1447,7 @@ def ExtractRPB(item, rpb_p):
                     fpfh.write(tfstr)
                     fpfh.close()
                     tf.close()
-                    status = 0
+                    # status = 0
         except Exception:
             logger.error("Cannot open Tar file: %s", tar_p)
             rc = 1
@@ -1589,7 +1588,7 @@ def getDGXmlData(xmlpath, stretch):
     return calibDict
 
 
-def GetIKcalibDict(metafile,stretch):
+def GetIKcalibDict(metafile, stretch):
     fp_mode = "renamed"
     metadict = getIKMetadata(fp_mode, metafile)
     #print(metadict)
@@ -1657,8 +1656,8 @@ def getIKMetadata(fp_mode, metafile):
         logger.error("Unable to parse metadata from %s", metafile)
         return None
 
-    metad_map = dict((c, p) for p in metad.getiterator() for c in p)  # Child/parent mapping
-    attribs = ["Source_Image_ID", "Component_ID"]  # nodes we need the attributes of
+    # metad_map = dict((c, p) for p in metad.getiterator() for c in p)  # Child/parent mapping
+    # attribs = ["Source_Image_ID", "Component_ID"]  # nodes we need the attributes of
 
     # We must identify the exact Source_Image_ID and Component_ID for this image
     # before loading the dictionary

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -220,6 +220,7 @@ BiasDict = {  # Spectral Irradiance in W/m2/um
 class ImageInfo:
     pass
 
+
 def buildParentArgumentParser():
 
     #### Set Up Arguments
@@ -340,7 +341,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
     if not err == 1:
         metafile = GetDGMetadataPath(info.srcfp)
         if metafile is None:
-            metafile = ExtractDGMetadataFile(info.srcfp,wd)
+            metafile = ExtractDGMetadataFile(info.srcfp, wd)
         if metafile is None:
             metafile = GetIKMetadataPath(info.srcfp)
         if metafile is None:
@@ -477,8 +478,8 @@ def stackIkBands(dstfp, members):
     meta_dict = {"NITF_IREP": "MULTI"}
 
     srcfp = members[0]
-    srcdir,srcfn = os.path.split(srcfp)
-    dstdir,dstfn = os.path.split(dstfp)
+    srcdir, srcfn = os.path.split(srcfp)
+    dstdir, dstfn = os.path.split(dstfp)
     vrt = os.path.splitext(dstfp)[0] + "_merge.vrt"
 
     #### Gather metadata from original blue image and save as strings for merge command
@@ -518,7 +519,6 @@ def stackIkBands(dstfp, members):
             if '"' not in tres[k]:
                 tre_list.append('-co "TRE={}={}"'.format(k, src_ds.GetMetadataItem(k, "TRE")))
 
-
         #### Close the source dataset
         src_ds = None
 
@@ -541,7 +541,7 @@ def stackIkBands(dstfp, members):
             rc = 1
 
         #print("Writing metadata to output")
-        dst_ds = gdal.Open(dstfp,gdalconst.GA_ReadOnly)
+        dst_ds = gdal.Open(dstfp, gdalconst.GA_ReadOnly)
         if dst_ds is not None:
             #### check that ds has correct number of bands
             if not dst_ds.RasterCount == len(band_dict):
@@ -559,16 +559,16 @@ def stackIkBands(dstfp, members):
         dst_ds = None
 
         #### also copy blue and rgb aux files
-        for fpi in glob.glob(os.path.join(srcdir,"{}.*".format(os.path.splitext(srcfn)[0]))):
-            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("blu", "msi"))
+        for fpi in glob.glob(os.path.join(srcdir, "{}.*".format(os.path.splitext(srcfn)[0]))):
+            fpo = os.path.join(dstdir, os.path.basename(fpi).replace("blu", "msi"))
             if not os.path.isfile(fpo) and not os.path.basename(fpi) == srcfn:
                 shutil.copy2(fpi, fpo)
-        for fpi in glob.glob(os.path.join(srcdir,"{}.*".format(os.path.splitext(srcfn)[0].replace("blu", "rgb")))):
-            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("rgb", "msi"))
+        for fpi in glob.glob(os.path.join(srcdir, "{}.*".format(os.path.splitext(srcfn)[0].replace("blu", "rgb")))):
+            fpo = os.path.join(dstdir, os.path.basename(fpi).replace("rgb", "msi"))
             if not os.path.isfile(fpo) and not os.path.basename(fpi) == srcfn:
                 shutil.copy2(fpi, fpo)
-        for fpi in glob.glob(os.path.join(srcdir,"{}.txt".format(os.path.splitext(srcfn)[0].replace("blu", "pan")))):
-            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("pan", "msi"))
+        for fpi in glob.glob(os.path.join(srcdir, "{}.txt".format(os.path.splitext(srcfn)[0].replace("blu", "pan")))):
+            fpo = os.path.join(dstdir, os.path.basename(fpi).replace("pan", "msi"))
             if not os.path.isfile(fpo):
                 shutil.copy2(fpi, fpo)
 
@@ -581,7 +581,7 @@ def stackIkBands(dstfp, members):
     return rc
 
 
-def calcStats(args,info):
+def calcStats(args, info):
 
     logger.info("Calculating image with stats")
     rc = 0
@@ -1386,43 +1386,42 @@ def overlap_check(geometry_wkt, spatial_ref, demPath):
     dem = gdal.Open(demPath, gdalconst.GA_ReadOnly)
 
     if dem is not None:
-            xsize = dem.RasterXSize
-            ysize = dem.RasterYSize
-            demProjection = dem.GetProjectionRef()
-            if demProjection:
+        xsize = dem.RasterXSize
+        ysize = dem.RasterYSize
+        demProjection = dem.GetProjectionRef()
+        if demProjection:
 
-                gtf = dem.GetGeoTransform()
+            gtf = dem.GetGeoTransform()
 
-                minx = gtf[0]
-                maxx = minx + xsize * gtf[1]
-                maxy = gtf[3]
-                miny = maxy + ysize * gtf[5]
+            minx = gtf[0]
+            maxx = minx + xsize * gtf[1]
+            maxy = gtf[3]
+            miny = maxy + ysize * gtf[5]
 
-                dem_geometry_wkt = 'POLYGON (( {} {}, {} {}, {} {}, {} {}, {} {} ))'.format(minx, miny, minx, maxy,
-                                                                                            maxx, maxy, maxx, miny,
-                                                                                            minx, miny)
-                demGeometry = ogr.CreateGeometryFromWkt(dem_geometry_wkt)
-                logger.info("DEM extent: %s", str(demGeometry))
-                demSpatialReference = osr.SpatialReference(demProjection)
+            dem_geometry_wkt = 'POLYGON (( {} {}, {} {}, {} {}, {} {}, {} {} ))'.format(minx, miny, minx, maxy, maxx,
+                                                                                        maxy, maxx, miny, minx, miny)
+            demGeometry = ogr.CreateGeometryFromWkt(dem_geometry_wkt)
+            logger.info("DEM extent: %s", str(demGeometry))
+            demSpatialReference = osr.SpatialReference(demProjection)
 
-                coordinateTransformer = osr.CoordinateTransformation(imageSpatialReference, demSpatialReference)
-                if not imageSpatialReference.IsSame(demSpatialReference):
-                    #logger.info("Image Spatial Refernce: %s", imageSpatialReference)
-                    #logger.info("DEM Spatial ReferenceL %s", emSpatialReference)
-                    #logger.info("Image Geometry before transformation: %s", imageGeometry)
-                    logger.info("Transforming image geometry to dem spatial reference")
-                    imageGeometry.Transform(coordinateTransformer)
-                    #logger.info("Image Geometry after transformation: %s", imageGeometry)
+            coordinateTransformer = osr.CoordinateTransformation(imageSpatialReference, demSpatialReference)
+            if not imageSpatialReference.IsSame(demSpatialReference):
+                #logger.info("Image Spatial Refernce: %s", imageSpatialReference)
+                #logger.info("DEM Spatial ReferenceL %s", emSpatialReference)
+                #logger.info("Image Geometry before transformation: %s", imageGeometry)
+                logger.info("Transforming image geometry to dem spatial reference")
+                imageGeometry.Transform(coordinateTransformer)
+                #logger.info("Image Geometry after transformation: %s", imageGeometry)
 
-                dem = None
-                overlap = imageGeometry.Within(demGeometry)
+            dem = None
+            overlap = imageGeometry.Within(demGeometry)
 
-                if overlap is False:
-                    logger.error("Image is not contained within DEM extent")
+            if overlap is False:
+                logger.error("Image is not contained within DEM extent")
 
-            else:
-                logger.error("DEM has no spatial reference information: %s", demPath)
-                overlap = False
+        else:
+            logger.error("DEM has no spatial reference information: %s", demPath)
+            overlap = False
 
     else:
         logger.error("Cannot open DEM to determine extent: %s", demPath)
@@ -1469,7 +1468,7 @@ def calcEarthSunDist(t):
     hr = t.hour
     minute = t.minute
     sec = t.second
-    ut = hr + (minute/60) + (sec/3600)
+    ut = hr + (minute / 60) + (sec / 3600)
     #print(ut)
 
     if month <= 2:
@@ -1515,7 +1514,6 @@ def getDGXmlData(xmlpath, stretch):
             else:
                 return None
 
-
             sunAngle = 90.0 - sunEl
             des = calcEarthSunDist(datetime.strptime(t, "%Y-%m-%dT%H:%M:%S.%fZ"))
 
@@ -1557,7 +1555,7 @@ def getDGXmlData(xmlpath, stretch):
                         units_factor = 10
 
             for band in abscalfact_dict:
-                satband = sat+'_'+band
+                satband = sat + '_' + band
                 if satband not in EsunDict:
                     logger.warning("Cannot find sensor and band in Esun lookup table: %s.  Try using --stretch "
                                    "ns.", satband)
@@ -1744,27 +1742,27 @@ def getGEMetadata(fp_mode, metafile):
     metad = utils.getGEMetadataAsXml(metafile)
     if metad is not None:
 
-            search_keys = ["originalFirstLineAcquisitionDateTime", "firstLineSunElevationAngle"]
-            for key in search_keys:
-                node = metad.find(".//{}".format(key))
-                if node is not None:
-                    metadict[key] = node.text
+        search_keys = ["originalFirstLineAcquisitionDateTime", "firstLineSunElevationAngle"]
+        for key in search_keys:
+            node = metad.find(".//{}".format(key))
+            if node is not None:
+                metadict[key] = node.text
 
-            band_keys = ["gain", "offset"]
-            for key in band_keys:
-                nodes = metad.findall(".//bandSpecificInformation")
+        band_keys = ["gain", "offset"]
+        for key in band_keys:
+            nodes = metad.findall(".//bandSpecificInformation")
 
-                vals = {}
-                for node in nodes:
-                    try:
-                        band = int(node.attrib["bandNumber"])
-                    except Exception:
-                        logger.error("Unable to retrieve band number in GE metadata")
-                    else:
-                        node = node.find(".//{}".format(key))
-                        if node is not None:
-                            vals[band] = node.text
-                metadict[key] = vals
+            vals = {}
+            for node in nodes:
+                try:
+                    band = int(node.attrib["bandNumber"])
+                except Exception:
+                    logger.error("Unable to retrieve band number in GE metadata")
+                else:
+                    node = node.find(".//{}".format(key))
+                    if node is not None:
+                        vals[band] = node.text
+            metadict[key] = vals
     else:
         logger.error("Unable to get metadata from %s", metafile)
 

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -1253,7 +1253,7 @@ def WarpImage(args, info):
         if not args.skip_warp:
             if rc != 1:
                 ####  Set RPC_DEM or RPC_HEIGHT transformation option
-                if args.dem != None:
+                if args.dem is not None:
                     logger.info('DEM: {}'.format(os.path.basename(args.dem)))
                     to = "RPC_DEM={}".format(args.dem)
 

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -1468,7 +1468,7 @@ def calcEarthSunDist(t):
     hr = t.hour
     minute = t.minute
     sec = t.second
-    ut = hr + (minute / 60) + (sec / 3600)
+    ut = hr + (minute / 60.) + (sec / 3600.)
     #print(ut)
 
     if month <= 2:

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -283,7 +283,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
     info.dstdir, info.dstfn = os.path.split(dstfp)
 
     starttime = datetime.today()
-    logger.info('Image: {}'.format(info.srcfn))
+    logger.info('Image: %s', info.srcfn)
 
     #### Get working dir
     if args.wd is not None:
@@ -295,7 +295,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
             os.makedirs(wd)
         except OSError:
             pass
-    logger.info("Working Dir: {}".format(wd))
+    logger.info("Working Dir: %s", wd)
 
     #### Derive names
     if args.wd:
@@ -311,7 +311,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
     try:
         spatial_ref = utils.SpatialRef(args.epsg)
     except RuntimeError:
-        logger.error("Invalid EPSG code: {0)".format(args.epsg))
+        logger.error("Invalid EPSG code: %i", args.epsg)
         err = 1
     else:
         args.spatial_ref = spatial_ref
@@ -346,7 +346,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
         if metafile is None:
             metafile = GetGEMetadataPath(info.srcfp)
         if metafile is None:
-            logger.error("Cannot find metadata for image: {0}".format(info.srcfp))
+            logger.error("Cannot find metadata for image: %s", info.srcfp)
             err = 1
         else:
             info.metapath = metafile
@@ -359,14 +359,14 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
             members = [os.path.join(info.srcdir, info.srcfn.replace("msi", b)) for b in ikMsiBands]
             status = [os.path.isfile(member) for member in members]
             if sum(status) != 4:
-                logger.error("1 or more IKONOS multispectral member images are missing {}".format(' '.join(members)))
+                logger.error("1 or more IKONOS multispectral member images are missing %s", ' '.join(members))
                 err = 1
             elif not os.path.isfile(info.localsrc):
                 rc = stackIkBands(info.localsrc, members)
                 #if not os.path.isfile(os.path.join(wd, os.path.basename(info.metapath))):
                 #    shutil.copy(info.metapath, os.path.join(wd, os.path.basename(info.metapath)))
                 if rc == 1:
-                    logger.error("Error building merged Ikonos image: {}".format(info.srcfp))
+                    logger.error("Error building merged Ikonos image: %s", info.srcfp)
                     err = 1
 
     if not err == 1 and args.wd:
@@ -386,7 +386,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
             copy_to_wd(info.localsrc, wd)
 
         else:
-            logger.warning("Source image does not exist: {}".format(info.srcfp))
+            logger.warning("Source image does not exist: %s", info.srcfp)
             err = 1
 
 
@@ -444,7 +444,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
         logger.error("Final image not present")
 
     if err == 1:
-        logger.error("Processing failed: {}".format(info.srcfn))
+        logger.error("Processing failed: %s", info.srcfn)
         if not args.save_temps:
             if args.wd:
                 utils.delete_temp_files([info.dstfp, info.rawvrt, info.warpfile, info.vrtfile, info.localsrc])
@@ -460,7 +460,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
     #### Calculate Total Time
     endtime = datetime.today()
     td = (endtime-starttime)
-    logger.info("Total Processing Time: {}\n".format(td))
+    logger.info("Total Processing Time: %s\n", td)
 
     return err
 
@@ -545,8 +545,8 @@ def stackIkBands(dstfp, members):
         if dst_ds is not None:
             #### check that ds has correct number of bands
             if not dst_ds.RasterCount == len(band_dict):
-                logger.error("Missing MSI band in stacked dataset.  Band count: {}, Required band count: {}".
-                             format(dst_ds.RasterCount, len(band_dict)))
+                logger.error("Missing MSI band in stacked dataset.  Band count: %i, Required band count: %i",
+                             dst_ds.RasterCount, len(band_dict))
                 rc = 1
 
             else:
@@ -577,7 +577,7 @@ def stackIkBands(dstfp, members):
     try:
         os.remove(vrt)
     except Exception as e:
-        logger.warning("Cannot remove file: {}, {}".format(vrt, e))
+        logger.warning("Cannot remove file: %s, %s", vrt, e)
     return rc
 
 
@@ -649,9 +649,8 @@ def calcStats(args,info):
                     LUT = ",".join(lLUT)
 
                 if info.stretch != "ns":
-                    logger.debug("Band Calibration Factors: {} {} {}".format(band,
-                                    CFlist[band - 1][0], CFlist[band - 1][1]))
-                logger.debug("Band stretch parameters: {} {}".format(band, LUT))
+                    logger.debug("Band Calibration Factors: %i %i %i", band, CFlist[band - 1][0], CFlist[band - 1][1])
+                logger.debug("Band stretch parameters: %i %s", band, LUT)
 
                 ComplexSourceXML = ('<ComplexSource>'
                                     '   <SourceFilename relativeToVRT="0">{0}</SourceFilename>'
@@ -668,10 +667,10 @@ def calcStats(args,info):
                 if vds.GetRasterBand(band).GetColorInterpretation() == gdalconst.GCI_AlphaBand:
                     vds.GetRasterBand(band).SetColorInterpretation(gdalconst.GCI_Undefined)
         else:
-            logger.error("Cannot create virtual dataset: {}".format(info.vrtfile))
+            logger.error("Cannot create virtual dataset: %s", info.vrtfile)
 
     else:
-        logger.error("Cannot open dataset: {}".format(info.warpfile))
+        logger.error("Cannot open dataset: %s", info.warpfile)
 
     vds = None
     wds = None
@@ -844,7 +843,7 @@ def GetImageStats(args, info, target_extent_geom=None):
             ll_geom.Transform(sg_ct)
             lr_geom.Transform(sg_ct)
             extent_geom.Transform(sg_ct)
-        logger.info("Geographic extent: {}".format(str(extent_geom)))
+        logger.info("Geographic extent: %s", str(extent_geom))
 
         #### Get geographic Envelope
         minlon, maxlon, minlat, maxlat = extent_geom.GetEnvelope()
@@ -856,14 +855,14 @@ def GetImageStats(args, info, target_extent_geom=None):
             ll_geom.Transform(gt_ct)
             lr_geom.Transform(gt_ct)
             extent_geom.Transform(gt_ct)
-        logger.info("Projected extent: {}".format(str(extent_geom)))
+        logger.info("Projected extent: %s", str(extent_geom))
         
         ## test user provided extent and ues if appropriate
         if target_extent_geom:
             if not extent_geom.Intersects(target_extent_geom):
                 rc = 1
             else:
-                logger.info("Using user-provided extent: {}".format(str(target_extent_geom)))
+                logger.info("Using user-provided extent: %s", str(target_extent_geom))
                 extent_geom = target_extent_geom
         
         if rc != 1:
@@ -877,7 +876,7 @@ def GetImageStats(args, info, target_extent_geom=None):
             minx, maxx, miny, maxy = extent_geom.GetEnvelope()
     
             #print(lons)
-            logger.info("Centroid: {}".format(str(centroid)))
+            logger.info("Centroid: %s", str(centroid))
     
             if maxlon - minlon > 180:
     
@@ -899,8 +898,7 @@ def GetImageStats(args, info, target_extent_geom=None):
                 info.res = "-tr {} {} ".format(args.resolution, args.resolution)
             else:
                 info.res = "-tr {0:.12f} {1:.12f} ".format(resx, resy)
-            logger.info("Original image size: {0} x {1}, res: {2:.12f} x {3:.12f}".format(rasterxsize_m, rasterysize_m,
-                                                                                          resx, resy))
+            logger.info("Original image size: %f x %f, res: %.12f x %.12f", rasterxsize_m, rasterysize_m, resx, resy)
     
             #### Set RGB bands
             info.rgb_bands = ""
@@ -915,7 +913,7 @@ def GetImageStats(args, info, target_extent_geom=None):
                 elif info.bands == 8:
                     info.rgb_bands = "-b 5 -b 3 -b 2 "
                 else:
-                    logger.error("Cannot get rgb bands from a {} band image".format(info.bands))
+                    logger.error("Cannot get rgb bands from a %i band image", info.bands)
                     rc = 1
     
             if args.bgrn is True:
@@ -926,7 +924,7 @@ def GetImageStats(args, info, target_extent_geom=None):
                 elif info.bands == 8:
                     info.rgb_bands = "-b 2 -b 3 -b 5 -b 7 "
                 else:
-                    logger.error("Cannot get bgrn bands from a {} band image".format(info.bands))
+                    logger.error("Cannot get bgrn bands from a %i band image", info.bands)
                     rc = 1
               
             info.stretch = args.stretch
@@ -936,7 +934,7 @@ def GetImageStats(args, info, target_extent_geom=None):
                 else:
                     info.stretch = 'mr'
     else:
-        logger.error("Cannot open dataset: {}".format(info.localsrc))
+        logger.error("Cannot open dataset: %s", info.localsrc)
         rc = 1
 
     return info, rc
@@ -1012,7 +1010,7 @@ def ExtractDGMetadataFile(srcfp, wd):
                         fpfh.close()
                         tf.close()
             except Exception:
-                logger.error("Cannot open Tar file: {}".format(tarpath))
+                logger.error("Cannot open Tar file: %s", tarpath)
 
     if metapath and os.path.isfile(metapath):
         return metapath
@@ -1092,7 +1090,7 @@ def WriteOutputMetadata(args, info):
         try:
             metad = ET.parse(metapath)
         except ET.ParseError:
-            logger.error("Invalid xml formatting in metadata file: {}".format(metapath))
+            logger.error("Invalid xml formatting in metadata file: %s", metapath)
             return 1
         else:
             imd = metad.find("IMD")
@@ -1254,17 +1252,17 @@ def WarpImage(args, info):
             if rc != 1:
                 ####  Set RPC_DEM or RPC_HEIGHT transformation option
                 if args.dem is not None:
-                    logger.info('DEM: {}'.format(os.path.basename(args.dem)))
+                    logger.info('DEM: %s', os.path.basename(args.dem))
                     to = "RPC_DEM={}".format(args.dem)
 
                 elif args.ortho_height is not None:
-                    logger.info("Elevation: {} meters".format(args.ortho_height))
+                    logger.info("Elevation: %f meters", args.ortho_height)
                     to = "RPC_HEIGHT={}".format(args.ortho_height)
 
                 else:
                     #### Get Constant Elevation From XML
                     h = get_rpc_height(info)
-                    logger.info("Average elevation: {} meters".format(h))
+                    logger.info("Average elevation: %f meters", h)
                     to = "RPC_HEIGHT={}".format(h)
                     ds = None
 
@@ -1367,16 +1365,16 @@ def GetCalibrationFactors(info):
             bandList = range(0, 3, 1)
 
     else:
-        logger.warning("Vendor or sensor not recognized: {}, {}".format(info.vendor, info.sat))
+        logger.warning("Vendor or sensor not recognized: %s, %s", info.vendor, info.sat)
 
-    #logger.info("Calibration factors: {}".format(calibDict))
+    #logger.info("Calibration factors: %s", calibDict)
     if len(calibDict) > 0:
 
         for band in bandList:
             if band in calibDict:
                 CFlist.append(calibDict[band])
 
-    logger.info("Calibration factor list: {}".format(CFlist))
+    logger.info("Calibration factor list: %s", CFlist)
     return CFlist
 
 
@@ -1404,17 +1402,17 @@ def overlap_check(geometry_wkt, spatial_ref, demPath):
                                                                                             maxx, maxy, maxx, miny,
                                                                                             minx, miny)
                 demGeometry = ogr.CreateGeometryFromWkt(dem_geometry_wkt)
-                logger.info("DEM extent: {}".format(demGeometry))
+                logger.info("DEM extent: %s", str(demGeometry))
                 demSpatialReference = osr.SpatialReference(demProjection)
 
                 coordinateTransformer = osr.CoordinateTransformation(imageSpatialReference, demSpatialReference)
                 if not imageSpatialReference.IsSame(demSpatialReference):
-                    #logger.info("Image Spatial Refernce: {}".format(imageSpatialReference))
-                    #logger.info("DEM Spatial ReferenceL {}".format(demSpatialReference))
-                    #logger.info("Image Geometry before transformation: {}".format(imageGeometry))
+                    #logger.info("Image Spatial Refernce: %s", imageSpatialReference)
+                    #logger.info("DEM Spatial ReferenceL %s", emSpatialReference)
+                    #logger.info("Image Geometry before transformation: %s", imageGeometry)
                     logger.info("Transforming image geometry to dem spatial reference")
                     imageGeometry.Transform(coordinateTransformer)
-                    #logger.info("Image Geometry after transformation: {}".format(imageGeometry))
+                    #logger.info("Image Geometry after transformation: %s", imageGeometry)
 
                 dem = None
                 overlap = imageGeometry.Within(demGeometry)
@@ -1423,11 +1421,11 @@ def overlap_check(geometry_wkt, spatial_ref, demPath):
                     logger.error("Image is not contained within DEM extent")
 
             else:
-                logger.error("DEM has no spatial reference information: {}".format(demPath))
+                logger.error("DEM has no spatial reference information: %s", demPath)
                 overlap = False
 
     else:
-        logger.error("Cannot open DEM to determine extent: {}".format(demPath))
+        logger.error("Cannot open DEM to determine extent: %s", demPath)
         overlap = False
 
     return overlap
@@ -1453,10 +1451,10 @@ def ExtractRPB(item, rpb_p):
                     tf.close()
                     status = 0
         except Exception:
-            logger.error("Cannot open Tar file: {}".format(tar_p))
+            logger.error("Cannot open Tar file: %s", tar_p)
             rc = 1
     else:
-        logger.info("Tar file does not exist: {}".format(tar_p))
+        logger.info("Tar file does not exist: %s", tar_p)
         rc = 1
 
     if rc == 1:
@@ -1496,7 +1494,7 @@ def getDGXmlData(xmlpath, stretch):
     try:
         xmldoc = minidom.parse(xmlpath)
     except Exception:
-        logger.error("Cannot parse metadata file: {}".format(xmlpath))
+        logger.error("Cannot parse metadata file: %s", xmlpath)
         return None
     else:
 
@@ -1561,8 +1559,8 @@ def getDGXmlData(xmlpath, stretch):
             for band in abscalfact_dict:
                 satband = sat+'_'+band
                 if satband not in EsunDict:
-                    logger.warning("Cannot find sensor and band in Esun lookup table: {}.  Try using --stretch "
-                                   "ns.".format(satband))
+                    logger.warning("Cannot find sensor and band in Esun lookup table: %s.  Try using --stretch "
+                                   "ns.", satband)
                     return None
                 else:
                     Esun = EsunDict[satband]
@@ -1578,11 +1576,11 @@ def getDGXmlData(xmlpath, stretch):
                             (Esun * math.cos(math.radians(sunAngle)) * effbandw)
                 refl_offset = units_factor * (bias * des ** 2 * math.pi) / (Esun * math.cos(math.radians(sunAngle)))
 
-                logger.info("{0}: \n\tabsCalFactor {1}\n\teffectiveBandwidth {2}\n\tEarth-Sun distance {3}"
-                            "\n\tEsun {4}\n\tSun angle {5}\n\tSun elev {6}\n\tGain {10}\n\tBias {11}"
-                            "\n\tUnits factor {9}\n\tReflectance correction {7}\n\tRadiance correction {8}".
-                            format(satband, abscal, effbandw, des, Esun, sunAngle, sunEl, refl_fact, rad_fact,
-                                   units_factor, gain, bias))
+                logger.info("%s: \n\tabsCalFactor %f\n\teffectiveBandwidth %f\n\tEarth-Sun distance %f"
+                            "\n\tEsun %f\n\tSun angle %f\n\tSun elev %f\n\tGain %f\n\tBias %f"
+                            "\n\tUnits factor %f\n\tReflectance correction %f\n\tRadiance correction %f", satband,
+                            abscal, effbandw, des, Esun, sunAngle, sunEl, gain, bias, units_factor, refl_fact,
+                            rad_fact)
 
                 if stretch == "rd":
                     calibDict[band] = (rad_fact, bias)
@@ -1625,9 +1623,9 @@ def GetIKcalibDict(metafile,stretch):
         rad_fact = 10000.0 / (calCoef * bw)
         refl_fact = (10000.0 * des ** 2 * math.pi) / (calCoef * bw * Esun * math.cos(math.radians(sunAngle)))
 
-        logger.info("{0}: calibration coef {1}, Earth-Sun distance {2}, Esun {3}, sun angle {4}, bandwidth {5}, "
-                    "reflectance factor {6}, radiance factor {7}".format(band, calCoef, des, Esun, sunAngle, bw,
-                                                                         refl_fact, rad_fact))
+        logger.info("%i: calibration coef %f, Earth-Sun distance %f, Esun %f, sun angle %f, bandwidth %f, "
+                    "reflectance factor %f radiance factor %f", band, calCoef, des, Esun, sunAngle, bw, refl_fact,
+                    rad_fact)
 
         if stretch == "rd":
             calibDict[band] = (rad_fact, 0)
@@ -1658,7 +1656,7 @@ def getIKMetadata(fp_mode, metafile):
         search_keys = dict(ik2fp)
 
     else:
-        logger.error("Unable to parse metadata from {}".format(metafile))
+        logger.error("Unable to parse metadata from %s", metafile)
         return None
 
     metad_map = dict((c, p) for p in metad.getiterator() for c in p)  # Child/parent mapping
@@ -1688,7 +1686,7 @@ def getIKMetadata(fp_mode, metafile):
             siid = os.path.basename(metafile.lower())[5:33]
         siid_nodes = metad.findall(r".//Source_Image_ID")
         if siid_nodes is None:
-            logger.error( "Could not find any Source Image ID fields in metadata {}".format(metafile))
+            logger.error("Could not find any Source Image ID fields in metadata %s", metafile)
             return None
 
         siid_node = None
@@ -1698,7 +1696,7 @@ def getIKMetadata(fp_mode, metafile):
                 break
 
         if siid_node is None:
-            logger.error("Could not locate SIID: {} in metadata {}".format(siid, metafile))
+            logger.error("Could not locate SIID: %s in metadata %s", siid, metafile)
             return None
 
 
@@ -1768,7 +1766,7 @@ def getGEMetadata(fp_mode, metafile):
                             vals[band] = node.text
                 metadict[key] = vals
     else:
-        logger.error("Unable to get metadata from {}".format(metafile))
+        logger.error("Unable to get metadata from %s", metafile)
 
     return metadict
 

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -504,10 +504,10 @@ def stackIkBands(dstfp, members):
         keys = m.keys()
         keys.sort()
         for k in keys:
-            if not '"' in m[k]:
+            if '"' not in m[k]:
                 m_list.append('-co "{}={}"'.format(k.replace("NITF_", ""), m[k]))
         for k in meta_dict.keys():
-            if not '"' in meta_dict[k]:
+            if '"' not in meta_dict[k]:
                 m_list.append('-co "{}={}"'.format(k.replace("NITF_", ""), meta_dict[k]))
 
         #### Get the TRE metadata
@@ -515,7 +515,7 @@ def stackIkBands(dstfp, members):
         #### Make the dictionary into a list
         tre_list = []
         for k in tres.keys():
-            if not '"' in tres[k]:
+            if '"' not in tres[k]:
                 tre_list.append('-co "TRE={}={}"'.format(k, src_ds.GetMetadataItem(k, "TRE")))
 
 
@@ -560,17 +560,17 @@ def stackIkBands(dstfp, members):
 
         #### also copy blue and rgb aux files
         for fpi in glob.glob(os.path.join(srcdir,"{}.*".format(os.path.splitext(srcfn)[0]))):
-            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("blu","msi"))
+            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("blu", "msi"))
             if not os.path.isfile(fpo) and not os.path.basename(fpi) == srcfn:
-                shutil.copy2(fpi,fpo)
-        for fpi in glob.glob(os.path.join(srcdir,"{}.*".format(os.path.splitext(srcfn)[0].replace("blu","rgb")))):
-            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("rgb","msi"))
+                shutil.copy2(fpi, fpo)
+        for fpi in glob.glob(os.path.join(srcdir,"{}.*".format(os.path.splitext(srcfn)[0].replace("blu", "rgb")))):
+            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("rgb", "msi"))
             if not os.path.isfile(fpo) and not os.path.basename(fpi) == srcfn:
-                shutil.copy2(fpi,fpo)
-        for fpi in glob.glob(os.path.join(srcdir,"{}.txt".format(os.path.splitext(srcfn)[0].replace("blu","pan")))):
-            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("pan","msi"))
+                shutil.copy2(fpi, fpo)
+        for fpi in glob.glob(os.path.join(srcdir,"{}.txt".format(os.path.splitext(srcfn)[0].replace("blu", "pan")))):
+            fpo = os.path.join(dstdir,os.path.basename(fpi).replace("pan", "msi"))
             if not os.path.isfile(fpo):
-                shutil.copy2(fpi,fpo)
+                shutil.copy2(fpi, fpo)
 
     else:
         rc = 1

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -4,7 +4,7 @@
 task handler classes and methods
 """
 
-import os, sys, string, shutil, glob, re, logging, subprocess, platform
+import os, sys, shutil, glob, re, logging, subprocess, platform
 import multiprocessing as mp
 
 #### Create Logger

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -117,8 +117,8 @@ class ParallelTaskHandler(object):
 
 def exec_cmd_mp(job):
     job_name, cmd = job
-    logger.info('Running job: {0}'.format(job_name))
-    logger.debug('Cmd: {0}'.format(cmd))
+    logger.info('Running job: %s', job_name)
+    logger.debug('Cmd: %s', cmd)
     if platform.system() == "Windows":
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     else:
@@ -145,13 +145,13 @@ def exec_cmd(cmd):
     err = 0
 
     if rc != 0:
-        logger.error("Error found - Return Code = {}:  {}".format(rc, cmd))
+        logger.error("Error found - Return Code = %s:  %s", rc, cmd)
         err = 1
     else:
-        logger.debug("Return Code = {}:  {}".format(rc, cmd))
+        logger.debug("Return Code = %s:  %s", rc, cmd)
 
-    logger.debug("STDOUT:  {}".format(so))
-    logger.debug("STDERR:  {}".format(se))
+    logger.debug("STDOUT:  %s", so)
+    logger.debug("STDERR:  %s", se)
     return err, so, se
 
 

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -161,7 +161,7 @@ def convert_optional_args_to_string(args, positional_arg_keys, arg_keys_to_remov
     arg_list = []
 
     ## Add optional args to arg_list
-    for k, v in args_dict.iteritems():
+    for k, v in args_dict.items():
         if k not in positional_arg_keys and k not in arg_keys_to_remove and v is not None:
             k = k.replace('_', '-')
             if isinstance(v, (list, tuple)):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -49,7 +49,7 @@ def get_bit_depth(outtype):
     elif outtype == "Float32":
         bitdepth = "f32"
     else:
-        logger.error("Invalid bit depth '{0}' supplied; must be 'Byte', 'UInt16', or 'Float32'.").format(outtype)
+        logger.error("Invalid bit depth '%s' supplied; must be 'Byte', 'UInt16', or 'Float32'.", outtype)
         return None
 
     return bitdepth
@@ -115,7 +115,7 @@ def find_images(inpath, is_textfile, target_exts):
             if os.path.isfile(image) and os.path.splitext(image)[1].lower() in target_exts:
                 image_list.append(image)
             else:
-                logger.debug("File in textfile does not exist or has an invalid extension: {}".format(image))
+                logger.debug("File in textfile does not exist or has an invalid extension: %s", image)
         t.close()
 
     else:
@@ -140,7 +140,7 @@ def find_images_with_exclude_list(inpath, is_textfile, target_exts, exclude_list
             if os.path.isfile(image) and os.path.splitext(image)[1].lower() in target_exts:
                 image_list.append(image)
             else:
-                logger.info("File in textfile does not exist or has an invalid extension: {}".format(image))
+                logger.info("File in textfile does not exist or has an invalid extension: %s", image)
         t.close()
 
     else:
@@ -158,7 +158,7 @@ def find_images_with_exclude_list(inpath, is_textfile, target_exts, exclude_list
         for image in image_list:
             exclude = [pattern for pattern in exclude_list if image in pattern]
             if exclude:
-                logger.debug("Scene ID matches pattern in exclude_list: {}".format(image))
+                logger.debug("Scene ID matches pattern in exclude_list: %s", image)
             else:
                 image_list2.append(image)
 
@@ -177,7 +177,7 @@ def delete_temp_files(names):
                 try:
                     os.remove(f)
                 except Exception as e:
-                    logger.warning('Could not remove {0}: {1}'.format(os.path.basename(f), e))
+                    logger.warning('Could not remove %s: %s', os.path.basename(f), e)
 
 
 def getGEMetadataAsXml(metafile):
@@ -185,10 +185,10 @@ def getGEMetadataAsXml(metafile):
         try:
             metaf = open(metafile, "r")
         except IOError as err:
-            logger.error("Could not open metadata file {0} because {1}".format(metafile, err))
+            logger.error("Could not open metadata file %s because %s", metafile, err)
             raise
     else:
-        logger.error("Metadata file {} not found".format(metafile))
+        logger.error("Metadata file %s not found", metafile)
         return None
 
     # Patterns to extract tag/value pairs and BEGIN/END group tags
@@ -268,7 +268,7 @@ def getIKMetadataAsXml(metafile):
         try:
             metaf = open(metafile, "r")
         except IOError as err:
-            logger.error("Could not open metadata file {0} because {1}".format(metafile, err))
+            logger.error("Could not open metadata file %s because %s", metafile, err)
             raise
     else:
         metaf = metafile

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -173,7 +173,7 @@ def delete_temp_files(names):
     for name in names:
         deleteList = glob.glob(os.path.splitext(name)[0] + '.*')
         for f in deleteList:
-            if not "log" in os.path.basename(f):
+            if "log" not in os.path.basename(f):
                 try:
                     os.remove(f)
                 except Exception as e:

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -366,7 +366,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
                 imginfo_list4.append(iinfo)
                 centroid = geom.Centroid()
                 logger.info("%s: geometry acquired - centroid: %f, %f", iinfo.srcfn, centroid.GetX(), centroid.GetY())
-                #print geom
+                #print(geom)
         else:
             logger.debug("Image has an invalid score: %s --> %i", iinfo.srcfp, iinfo.score)
 
@@ -660,7 +660,7 @@ def build_shp(contribs, shp, args, params):
                 mean_list = []
                 stdev_list = []
                 px_cnt_list = []
-                keys = iinfo.stat_dct.keys()
+                keys = list(iinfo.stat_dct.keys())
                 keys.sort()
                 for band in keys:
                     imin, imax, imean, istdev = iinfo.stat_dct[band]
@@ -678,7 +678,7 @@ def build_shp(contribs, shp, args, params):
                 feat.SetField("STATS_PXCT", ",".join(px_cnt_list))
 
         if params.median_remove is True:
-            keys = iinfo.median.keys()
+            keys = list(iinfo.median.keys())
             keys.sort()
             median_list = [str(iinfo.median[band]) for band in keys]
             feat.SetField("MEDIAN", ",".join(median_list))

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -494,7 +494,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             if contrib_geom.Intersects(t.geom):
                 if args.median_remove:
                     ## parse median dct into text
-                    median_string = ";".join(["{}:{}".format(k, v) for k, v in iinfo.median.iteritems()])
+                    median_string = ";".join(["{}:{}".format(k, v) for k, v in iinfo.median.items()])
                     intersects.append("{},{}".format(iinfo.srcfp, median_string))
                 else:
                     intersects.append(iinfo.srcfp)

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -96,7 +96,7 @@ def main():
         else:
             qsubpath = os.path.abspath(args.qsubscript)
         if not os.path.isfile(qsubpath):
-            parser.error("qsub script path is not valid: %s" %qsubpath)
+            parser.error("qsub script path is not valid: {}".format(qsubpath))
         
     ## Verify processing options do not conflict
     if args.pbs and args.slurm:
@@ -108,7 +108,7 @@ def main():
     elif os.path.isdir(inpath):
         bTextfile = False
     else:
-        parser.error("Arg1 is not a valid file path or directory: %s" %inpath)    
+        parser.error("Arg1 is not a valid file path or directory: {}".format(inpath))
     
     
     #### Validate target day option
@@ -195,7 +195,7 @@ def main():
             l = "-l {}".format(args.l) if args.l else ""
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 task_handler.run_tasks(task_queue)
@@ -203,7 +203,7 @@ def main():
         elif args.slurm:
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 task_handler.run_tasks(task_queue)
@@ -211,7 +211,7 @@ def main():
         else:
             try:
                 run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_arg_keys)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             
         
@@ -271,11 +271,11 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     image_list_unique = list(set(image_list))
     dupes = [x for n,x in enumerate(image_list) if x in image_list[:n]]
     if len(dupes) > 0:
-        logger.info("Removed {0} duplicate image paths".format(len(dupes)))
-        logger.debug("Dupes: {0}".format(dupes))
+        logger.info("Removed %i duplicate image paths", len(dupes))
+        logger.debug("Dupes: %s", dupes)
     image_list = image_list_unique
 
-    logger.info("%i existing images found" %len(image_list))
+    logger.info("%i existing images found", len(image_list))
     
     #### gather image info list
     logger.info("Getting image info")
@@ -284,8 +284,8 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     #### Get mosaic parameters
     logger.info("Setting mosaic parameters")
     params = mosaic.getMosaicParameters(imginfo_list[0],args)
-    logger.info("Mosaic parameters: band count={}, datatype={}".format(params.bands,params.datatype))
-    logger.info("Mosaic parameters: projection={}".format(params.proj))
+    logger.info("Mosaic parameters: band count=%i, datatype=%s", params.bands, params.datatype)
+    logger.info("Mosaic parameters: projection=%s", params.proj)
      
     #### Remove images that do not match ref
     logger.info("Applying attribute filter")
@@ -294,7 +294,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     if len(imginfo_list2) == 0:
         raise RuntimeError("No valid images found.  Check input filter parameters.")
 
-    logger.info("{} of {} images match filter".format(len(imginfo_list2),len(image_list)))
+    logger.info("%i of %i images match filter", len(imginfo_list2), len(image_list))
 
     #### if extent is specified, build tile params and compare extent to input image geom
     if args.extent:
@@ -325,8 +325,9 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     if len(imginfo_list3) == 0:
         raise RuntimeError("No images found that intersect mosaic extent")
     
-    logger.info("Mosaic parameters: resolution %f x %f, tilesize %f x %f, extent %f %f %f %f" %(params.xres,params.yres,params.xtilesize,params.ytilesize,params.xmin,params.xmax,params.ymin,params.ymax))
-    logger.info("%d of %d input images intersect mosaic extent" %(len(imginfo_list3),len(imginfo_list2)))
+    logger.info("Mosaic parameters: resolution %f x %f, tilesize %f x %f, extent %f %f %f %f", params.xres,
+                params.yres, params.xtilesize, params.ytilesize, params.xmin, params.xmax, params.ymin, params.ymax)
+    logger.info("%d of %d input images intersect mosaic extent", len(imginfo_list3), len(imginfo_list2))
     
     ## Sort images by score
     logger.info("Reading image metadata and determining sort order")
@@ -356,10 +357,10 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
                 tm = datetime.today()
                 imginfo_list4.append(iinfo)
                 centroid = geom.Centroid()
-                logger.info("%s: geometry acquired - centroid: %f, %f" %(iinfo.srcfn, centroid.GetX(), centroid.GetY()))
+                logger.info("%s: geometry acquired - centroid: %f, %f", iinfo.srcfn, centroid.GetX(), centroid.GetY())
                 #print geom
         else:
-            logger.debug("Image has an invalid score: %s --> %i" %(iinfo.srcfp, iinfo.score))
+            logger.debug("Image has an invalid score: %s --> %i", iinfo.srcfp, iinfo.score)
 
     if not all_valid:
         raise RuntimeError("Some source images do not have valid geometries.  Cannot proceeed")
@@ -376,13 +377,13 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
         
         if args.mode == "ALL" or args.mode == "SHP":
             contribs = [(iinfo,iinfo.geom) for iinfo in imginfo_list4]
-            logger.info("Number of contributors: %d" %len(contribs))
+            logger.info("Number of contributors: %d", len(contribs))
             
             logger.info("Building component index")
             comp_shp = mosaicname + "_components.shp"
             if len(contribs) > 0:
                 if os.path.isfile(comp_shp):
-                    logger.info("Components shapefile already exists: %s" %comp_shp)
+                    logger.info("Components shapefile already exists: %s", comp_shp)
                 else:
                     build_shp(contribs, comp_shp, args, params)
     
@@ -394,14 +395,14 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     ####  Overlay geoms and remove non-contributors
     logger.info("Overlaying images to determine contribution geom")
     contribs = mosaic.determine_contributors(imginfo_list4,params.extent_geom,args.min_contribution_area)
-    logger.info("Number of contributors: %d" %len(contribs))
+    logger.info("Number of contributors: %d", len(contribs))
     
     if args.mode == "ALL" or args.mode == "SHP":
         logger.info("Building cutlines index")
         shp = mosaicname + "_cutlines.shp"
         if len(contribs) > 0:
             if os.path.isfile(shp):
-                logger.info("Cutlines shapefile already exists: %s" %shp)
+                logger.info("Cutlines shapefile already exists: %s", shp)
             else:
                 build_shp(contribs, shp, args, params)
     
@@ -414,7 +415,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     
     xtiledim = math.ceil((params.xmax-params.xmin)/params.xtilesize)
     ytiledim = math.ceil((params.ymax-params.ymin)/params.ytilesize)
-    logger.info("Tiles: %d rows, %d columns" %(ytiledim,xtiledim))
+    logger.info("Tiles: %d rows, %d columns", ytiledim, xtiledim)
     
     xtdb = len(str(int(xtiledim)))
     ytdb = len(str(int(ytiledim)))
@@ -473,10 +474,10 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     )
     tile_arg_str = taskhandler.convert_optional_args_to_string(args, pos_arg_keys, arg_keys_to_remove)
     
-    logger.debug("Identifying components of {} subtiles".format(len(tiles)))
+    logger.debug("Identifying components of %i subtiles", len(tiles))
     i = 0
     for t in tiles:
-        logger.debug("Identifying components of tile {} of {}: {}".format(i,len(tiles),os.path.basename(t.name)))
+        logger.debug("Identifying components of tile %i of %i: %s", i, len(tiles), os.path.basename(t.name))
         
         ####    determine which images in each tile - create geom and query image geoms
         logger.debug("Running intersect with imagery")       
@@ -496,14 +497,14 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             
                         
             tile_basename = os.path.basename(os.path.splitext(t.name)[0])                                    
-            logger.info("Number of contributors to subtile {}: {}".format(tile_basename,len(intersects)))
+            logger.info("Number of contributors to subtile %s: %i", tile_basename, len(intersects))
             itpath = os.path.join(mosaic_dir,tile_basename+"_intersects.txt")
             it = open(itpath,"w")
             it.write(string.join(intersects,"\n"))
             it.close()
             
             #### Submit QSUB job
-            logger.debug("Building mosaicking job for tile: %s" %os.path.basename(t.name))
+            logger.debug("Building mosaicking job for tile: %s", os.path.basename(t.name))
             if not os.path.isfile(t.name):
                 
                 cmd = r'{} {} -e {} {} {} {} -r {} {} -b {} {} {}'.format(
@@ -532,7 +533,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
                     task_queue.append(task)
                 
             else:
-                logger.info("Tile already exists: %s" %os.path.basename(t.name))
+                logger.info("Tile already exists: %s", os.path.basename(t.name))
         i += 1
 
     if args.mode == "ALL" or args.mode == "MOSAIC":
@@ -542,11 +543,11 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if task_handler.num_processes > 1:
-                    logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))
+                    logger.info("Number of child processes to spawn: %i", task_handler.num_processes)
                 task_handler.run_tasks(task_queue)
                 
             logger.info("Done")
@@ -557,7 +558,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
 
 
 def build_shp(contribs, shp, args, params):
-    logger.info("Creating shapefile of image boundaries: %s" %shp)
+    logger.info("Creating shapefile of image boundaries: %s", shp)
     
     fields = (
         ("IMAGENAME", ogr.OFTString, 100),
@@ -594,7 +595,7 @@ def build_shp(contribs, shp, args, params):
     
     ogrDriver = ogr.GetDriverByName(OGR_DRIVER)
     if ogrDriver is None:
-        logger.info("OGR: Driver %s is not available" % OGR_DRIVER)
+        logger.info("OGR: Driver %s is not available", OGR_DRIVER)
         sys.exit(-1)
     
     if os.path.isfile(shp):
@@ -612,7 +613,7 @@ def build_shp(contribs, shp, args, params):
     
     lyr = vds.CreateLayer(shpbn, rp, ogr.wkbPolygon)
     if lyr is None:
-        logger.info("ERROR: Failed to create layer: %s" % shpbn)
+        logger.info("ERROR: Failed to create layer: %s", shpbn)
         sys.exit(-1)
     
     for fld, fdef, flen in fields:
@@ -620,7 +621,7 @@ def build_shp(contribs, shp, args, params):
         if fdef == ogr.OFTString:
             field_defn.SetWidth(flen)
         if lyr.CreateField(field_defn) != 0:
-            logger.info("ERROR: Failed to create field: %s" % fld)
+            logger.info("ERROR: Failed to create field: %s", fld)
     
     for iinfo,geom in contribs:
                 
@@ -677,12 +678,12 @@ def build_shp(contribs, shp, args, params):
             keys.sort()
             median_list = [str(iinfo.median[band]) for band in keys]
             feat.SetField("MEDIAN", ",".join(median_list))
-            #logger.info("median = {}".format(",".join(median_list)))
+            #logger.info("median = %s", ",".join(median_list))
             
         feat.SetGeometry(geom)
         
         if lyr.CreateFeature(feat) != 0:
-            logger.info("ERROR: Could not create feature for image %s" % iinfo.srcfn)
+            logger.info("ERROR: Could not create feature for image %s", iinfo.srcfn)
             
         feat.Destroy()
     
@@ -690,9 +691,9 @@ def build_shp(contribs, shp, args, params):
 def build_tiles_shp(mosaicname, tiles, params):
     tiles_shp = mosaicname + "_tiles.shp"
     if os.path.isfile(tiles_shp):
-        logger.info("Tiles shapefile already exists: %s" %os.path.basename(tiles_shp))
+        logger.info("Tiles shapefile already exists: %s", os.path.basename(tiles_shp))
     else:
-        logger.info("Creating shapefile of tiles: %s" %os.path.basename(tiles_shp))
+        logger.info("Creating shapefile of tiles: %s", os.path.basename(tiles_shp))
         fields = [('ROW', ogr.OFTInteger, 4),
                 ('COL', ogr.OFTInteger, 4),
                 ("TILENAME", ogr.OFTString, 100),
@@ -704,7 +705,7 @@ def build_tiles_shp(mosaicname, tiles, params):
         OGR_DRIVER = "ESRI Shapefile"
         ogrDriver = ogr.GetDriverByName(OGR_DRIVER)
         if ogrDriver is None:
-            logger.error("OGR: Driver %s is not available" % OGR_DRIVER)
+            logger.error("OGR: Driver %s is not available", OGR_DRIVER)
             sys.exit(-1)
     
         if os.path.isfile(tiles_shp):
@@ -722,7 +723,7 @@ def build_tiles_shp(mosaicname, tiles, params):
         
         lyr = vds.CreateLayer(shpbn, rp, ogr.wkbPolygon)
         if lyr is None:
-            logger.error("ERROR: Failed to create layer: %s" % shpbn)
+            logger.error("ERROR: Failed to create layer: %s", shpbn)
             sys.exit(-1)
         
         for fld, fdef, flen in fields:
@@ -730,7 +731,7 @@ def build_tiles_shp(mosaicname, tiles, params):
             if fdef == ogr.OFTString:
                 field_defn.SetWidth(flen)
             if lyr.CreateField(field_defn) != 0:
-                logger.error("ERROR: Failed to create field: %s" % fld)
+                logger.error("ERROR: Failed to create field: %s", fld)
         
         for t in tiles:
             feat = ogr.Feature(lyr.GetLayerDefn())
@@ -744,7 +745,7 @@ def build_tiles_shp(mosaicname, tiles, params):
             feat.SetGeometry(t.geom)
             
             if lyr.CreateFeature(feat) != 0:
-                logger.error("ERROR: Could not create feature for tile %s" % t)
+                logger.error("ERROR: Could not create feature for tile %s", t)
             feat.Destroy()
             
 

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -1,4 +1,4 @@
-import os, string, sys, shutil, glob, re, tarfile, logging, argparse, subprocess, math
+import os, sys, shutil, glob, re, tarfile, logging, argparse, subprocess, math
 from datetime import datetime, date, timedelta
 from xml.etree import cElementTree as ET
 import gdal, ogr, osr, gdalconst
@@ -500,7 +500,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             logger.info("Number of contributors to subtile %s: %i", tile_basename, len(intersects))
             itpath = os.path.join(mosaic_dir,tile_basename+"_intersects.txt")
             it = open(itpath,"w")
-            it.write(string.join(intersects,"\n"))
+            it.write("\n".join(intersects))
             it.close()
             
             #### Submit QSUB job

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -13,6 +13,7 @@ logger.setLevel(logging.DEBUG)
 default_qsub_script = "qsub_mosaic.sh"
 default_logfile = "mosaic.log"
 
+
 def main():
 
     #### Set Up Arguments 
@@ -22,14 +23,15 @@ def main():
     
     parser.add_argument("src", help="textfile or directory of input rasters (tif only)")
     parser.add_argument("mosaicname", help="output mosaic name excluding extension")
-    pos_arg_keys = ["src","mosaicname"]
+    pos_arg_keys = ["src", "mosaicname"]
 
     parser.add_argument("-r", "--resolution", nargs=2, type=float,
                         help="output pixel resolution -- xres yres (default is same as first input file)")
     parser.add_argument("-e", "--extent", nargs=4, type=float,
                         help="extent of output mosaic -- xmin xmax ymin ymax (default is union of all inputs)")
     parser.add_argument("-t", "--tilesize", nargs=2, type=float,
-                        help="tile size in coordinate system units -- xsize ysize (default is 40,000 times output resolution)")
+                        help="tile size in coordinate system units -- xsize ysize (default is 40,000 times output "
+                             "resolution)")
     parser.add_argument("--force-pan-to-multi", action="store_true", default=False,
                         help="if output is multiband, force script to also use 1 band images")
     parser.add_argument("-b", "--bands", type=int,
@@ -39,7 +41,9 @@ def main():
     parser.add_argument("--tyear",
                         help="year (or year range) to use as target for image suitability ranking -- 2017 or 2015-2017")
     parser.add_argument("--nosort", action="store_true", default=False,
-                        help="do not sort images by metadata. script uses the order of the input textfile or directory (first image is first drawn).  Not recommended if input is a directory; order will be random")
+                        help="do not sort images by metadata. script uses the order of the input textfile or directory "
+                             "(first image is first drawn).  Not recommended if input is a directory; order will be "
+                             "random")
     parser.add_argument("--use-exposure", action="store_true", default=False,
                         help="use exposure settings in metadata to inform score")
     parser.add_argument("--exclude",
@@ -49,21 +53,24 @@ def main():
     parser.add_argument("--include-all-ms", action="store_true", default=False,
                         help="include all multispectral imagery, even if the imagery has differing numbers of bands")
     parser.add_argument("--min-contribution-area", type=int, default=20000000,
-                      help="minimum area contribution threshold in target projection units (default=20000000). Higher values remove more image slivers from the resulting mosaic") 
+                        help="minimum area contribution threshold in target projection units (default=20000000). "
+                             "Higher values remove more image slivers from the resulting mosaic")
     parser.add_argument("--median-remove", action="store_true", default=False,
-                        help="subtract the median from each input image before forming the mosaic in order to correct for contrast")
-    parser.add_argument("--mode", choices=mosaic.MODES , default="ALL",
-                        help=" mode: ALL- all steps (default), SHP- create shapefiles, MOSAIC- create tiled tifs, TEST- create log only")
+                        help="subtract the median from each input image before forming the mosaic in order to correct "
+                             "for contrast")
+    parser.add_argument("--mode", choices=mosaic.MODES, default="ALL",
+                        help=" mode: ALL- all steps (default), SHP- create shapefiles, MOSAIC- create tiled tifs, "
+                             "TEST- create log only")
     parser.add_argument("--wd",
                         help="scratch space (default is mosaic directory)")
     parser.add_argument("--component-shp", action="store_true", default=False,
                         help="create shp of all componenet images")
     parser.add_argument("--cutline-step", type=int, default=2,
-                       help="cutline calculator pixel skip interval (default=2)")
+                        help="cutline calculator pixel skip interval (default=2)")
     parser.add_argument("--calc-stats", action="store_true", default=False,
-                       help="calculate image stats and record them in the index")
+                        help="calculate image stats and record them in the index")
     parser.add_argument("--gtiff-compression", choices=mosaic.GTIFF_COMPRESSIONS, default="lzw",
-                        help="GTiff compression type. Default=lzw (%s)"%(",".join(mosaic.GTIFF_COMPRESSIONS)))
+                        help="GTiff compression type. Default=lzw ({})".format(",".join(mosaic.GTIFF_COMPRESSIONS)))
     parser.add_argument("--pbs", action='store_true', default=False,
                         help="submit tasks to PBS")
     parser.add_argument("--slurm", action='store_true', default=False,
@@ -71,11 +78,12 @@ def main():
     parser.add_argument("--parallel-processes", type=int, default=1,
                         help="number of parallel processes to spawn (default 1)")
     parser.add_argument("--qsubscript",
-                        help="submission script to use in PBS/SLURM submission (PBS default is qsub_mosaic.sh, SLURM default is slurm_mosaic.py, in script root folder)")
+                        help="submission script to use in PBS/SLURM submission (PBS default is qsub_mosaic.sh, SLURM "
+                             "default is slurm_mosaic.py, in script root folder)")
     parser.add_argument("-l",
                         help="PBS resources requested (mimicks qsub syntax). Use only on HPC systems.")
     parser.add_argument("--log",
-                        help="file to log progress (default is <output dir>\%s" %default_logfile)
+                        help="file to log progress (default is <output dir>\{}".format(default_logfile))
     
     #### Parse Arguments
     args = parser.parse_args()
@@ -84,15 +92,15 @@ def main():
     mosaicname = os.path.abspath(args.mosaicname)
     mosaicname = os.path.splitext(mosaicname)[0]
     mosaic_dir = os.path.dirname(mosaicname)
-    tile_builder_script = os.path.join(os.path.dirname(scriptpath),'pgc_mosaic_build_tile.py')
+    tile_builder_script = os.path.join(os.path.dirname(scriptpath), 'pgc_mosaic_build_tile.py')
     
     ## Verify qsubscript
     if args.pbs or args.slurm:
         if args.qsubscript is None:
             if args.pbs:
-                qsubpath = os.path.join(os.path.dirname(scriptpath),'qsub_mosaic.sh')
+                qsubpath = os.path.join(os.path.dirname(scriptpath), 'qsub_mosaic.sh')
             if args.slurm:
-                qsubpath = os.path.join(os.path.dirname(scriptpath),'slurm_mosaic.sh')
+                qsubpath = os.path.join(os.path.dirname(scriptpath), 'slurm_mosaic.sh')
         else:
             qsubpath = os.path.abspath(args.qsubscript)
         if not os.path.isfile(qsubpath):
@@ -109,14 +117,13 @@ def main():
         bTextfile = False
     else:
         parser.error("Arg1 is not a valid file path or directory: {}".format(inpath))
-    
-    
+
     #### Validate target day option
     if args.tday is not None:
         try:
             m = int(args.tday.split("-")[0])
             d = int(args.tday.split("-")[1])
-            td = date(2000,m,d)
+            td = date(2000, m, d)
         except ValueError:
             parser.error("Target day must be in mm-dd format (i.e 04-05)")
             sys.exit(1)
@@ -213,8 +220,7 @@ def main():
                 run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_arg_keys)
             except RuntimeError as e:
                 logger.error(e)
-            
-        
+
     else:
         logger.info("No tasks to process")
         
@@ -233,17 +239,17 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     if args.log is not None:
         logfile = os.path.abspath(args.log)
     else:
-        logfile = os.path.join(mosaic_dir,default_logfile)
+        logfile = os.path.join(mosaic_dir, default_logfile)
     
     lfh = logging.FileHandler(logfile)
     lfh.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
     lfh.setFormatter(formatter)
     logger.addHandler(lfh)
     
     lsh = logging.StreamHandler()
     lsh.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
     lsh.setFormatter(formatter)
     logger.addHandler(lsh)
   
@@ -269,7 +275,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
 
     # remove duplicate images
     image_list_unique = list(set(image_list))
-    dupes = [x for n,x in enumerate(image_list) if x in image_list[:n]]
+    dupes = [x for n, x in enumerate(image_list) if x in image_list[:n]]
     if len(dupes) > 0:
         logger.info("Removed %i duplicate image paths", len(dupes))
         logger.debug("Dupes: %s", dupes)
@@ -279,17 +285,17 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     
     #### gather image info list
     logger.info("Getting image info")
-    imginfo_list = [mosaic.ImageInfo(image,"IMAGE") for image in image_list]
+    imginfo_list = [mosaic.ImageInfo(image, "IMAGE") for image in image_list]
     
     #### Get mosaic parameters
     logger.info("Setting mosaic parameters")
-    params = mosaic.getMosaicParameters(imginfo_list[0],args)
+    params = mosaic.getMosaicParameters(imginfo_list[0], args)
     logger.info("Mosaic parameters: band count=%i, datatype=%s", params.bands, params.datatype)
     logger.info("Mosaic parameters: projection=%s", params.proj)
      
     #### Remove images that do not match ref
     logger.info("Applying attribute filter")
-    imginfo_list2 = mosaic.filterMatchingImages(imginfo_list,params)
+    imginfo_list2 = mosaic.filterMatchingImages(imginfo_list, params)
     
     if len(imginfo_list2) == 0:
         raise RuntimeError("No valid images found.  Check input filter parameters.")
@@ -311,16 +317,18 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
                 ys = ys + iinfo.ys
                 imginfo_list3.append(iinfo)
             else: # remove from list if no geom
-                logger.debug("Null geometry for image: %s" %iinfo.srcfn)
+                logger.debug("Null geometry for image: %s", iinfo.srcfn)
         
         params.xmin = min(xs)
         params.xmax = max(xs)
         params.ymin = min(ys)
         params.ymax = max(ys)
     
-        poly_wkt = 'POLYGON (( %f %f, %f %f, %f %f, %f %f, %f %f ))' %(params.xmin,params.ymin,params.xmin,params.ymax,params.xmax,params.ymax,params.xmax,params.ymin,params.xmin,params.ymin)
+        poly_wkt = 'POLYGON (( {} {}, {} {}, {} {}, {} {}, {} {} ))'.format(params.xmin, params.ymin, params.xmin,
+                                                                            params.ymax, params.xmax, params.ymax,
+                                                                            params.xmax, params.ymin, params.xmin,
+                                                                            params.ymin)
         params.extent_geom = ogr.CreateGeometryFromWkt(poly_wkt)
-     
 
     if len(imginfo_list3) == 0:
         raise RuntimeError("No images found that intersect mosaic extent")
@@ -338,19 +346,19 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
         imginfo_list3.sort(key=lambda x: x.score)
     
     logger.info("Getting Exact Image geometry")
-    imginfo_list4 =[]
+    imginfo_list4 = []
     all_valid = True
 
     for iinfo in imginfo_list3:
         if iinfo.score > 0 or args.nosort:
             simplify_tolerance = 2.0 * ((params.xres + params.yres) / 2.0) ## 2 * avg(xres, yres), should be 1 for panchromatic mosaics where res = 0.5m
-            geom,xs1,ys1 = mosaic.GetExactTrimmedGeom(iinfo.srcfp,step=args.cutline_step,tolerance=simplify_tolerance)
+            geom, xs1, ys1 = mosaic.GetExactTrimmedGeom(iinfo.srcfp, step=args.cutline_step, tolerance=simplify_tolerance)
                 
             if geom is None:
-                logger.warning("%s: geometry could not be determined, verify image is valid" %iinfo.srcfn)
+                logger.warning("%s: geometry could not be determined, verify image is valid", iinfo.srcfn)
                 all_valid = False
             elif geom.IsEmpty():
-                logger.warning("%s: geometry is empty" %iinfo.srcfn)
+                logger.warning("%s: geometry is empty", iinfo.srcfn)
                 all_valid = False
             else:
                 iinfo.geom = geom
@@ -370,13 +378,13 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     for iinfo in imginfo_list4:
         logger.info(iinfo.srcfn)
         if args.calc_stats or args.median_remove:
-            iinfo.get_raster_stats(args.calc_stats,args.median_remove)
+            iinfo.get_raster_stats(args.calc_stats, args.median_remove)
     
     # Build componenet index
     if args.component_shp:
         
         if args.mode == "ALL" or args.mode == "SHP":
-            contribs = [(iinfo,iinfo.geom) for iinfo in imginfo_list4]
+            contribs = [(iinfo, iinfo.geom) for iinfo in imginfo_list4]
             logger.info("Number of contributors: %d", len(contribs))
             
             logger.info("Building component index")
@@ -390,11 +398,10 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             else:
                 logger.error("No contributing images")
 
-
     # Build cutlines index                    
     ####  Overlay geoms and remove non-contributors
     logger.info("Overlaying images to determine contribution geom")
-    contribs = mosaic.determine_contributors(imginfo_list4,params.extent_geom,args.min_contribution_area)
+    contribs = mosaic.determine_contributors(imginfo_list4, params.extent_geom, args.min_contribution_area)
     logger.info("Number of contributors: %d", len(contribs))
     
     if args.mode == "ALL" or args.mode == "SHP":
@@ -413,29 +420,29 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
     ## Create tile objects
     tiles = []
     
-    xtiledim = math.ceil((params.xmax-params.xmin)/params.xtilesize)
-    ytiledim = math.ceil((params.ymax-params.ymin)/params.ytilesize)
+    xtiledim = math.ceil((params.xmax-params.xmin) / params.xtilesize)
+    ytiledim = math.ceil((params.ymax-params.ymin) / params.ytilesize)
     logger.info("Tiles: %d rows, %d columns", ytiledim, xtiledim)
     
     xtdb = len(str(int(xtiledim)))
     ytdb = len(str(int(ytiledim)))
     
     i = 1   
-    for x in mosaic.drange(params.xmin,params.xmax,params.xtilesize):  # Columns
-        if x+params.xtilesize > params.xmax:
+    for x in mosaic.drange(params.xmin, params.xmax, params.xtilesize):  # Columns
+        if x + params.xtilesize > params.xmax:
             x2 = params.xmax
         else:
-            x2 = x+params.xtilesize
+            x2 = x + params.xtilesize
       
         j = 1
-        for y in mosaic.drange(params.ymin,params.ymax,params.ytilesize):  # Rows
-            if y+params.ytilesize > params.ymax:
+        for y in mosaic.drange(params.ymin, params.ymax, params.ytilesize):  # Rows
+            if y + params.ytilesize > params.ymax:
                 y2 = params.ymax
             else:
-                y2 = y+params.ytilesize
+                y2 = y + params.ytilesize
                         
-            tilename = "{}_{}_{}.tif".format(mosaicname,mosaic.buffernum(j,ytdb),mosaic.buffernum(i,xtdb))
-            tile = mosaic.TileParams(x,x2,y,y2,j,i,tilename)
+            tilename = "{}_{}_{}.tif".format(mosaicname, mosaic.buffernum(j, ytdb), mosaic.buffernum(i, xtdb))
+            tile = mosaic.TileParams(x, x2, y, y2, j, i, tilename)
             tiles.append(tile)
             j += 1
         i += 1
@@ -487,19 +494,18 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             if contrib_geom.Intersects(t.geom):
                 if args.median_remove:
                     ## parse median dct into text
-                    median_string = ";".join(["{}:{}".format(k,v) for k,v in iinfo.median.iteritems()])
+                    median_string = ";".join(["{}:{}".format(k, v) for k, v in iinfo.median.iteritems()])
                     intersects.append("{},{}".format(iinfo.srcfp, median_string))
                 else:
                     intersects.append(iinfo.srcfp)
                                 
         ####  If any images are in the tile, mosaic them
         if len(intersects) > 0:
-            
-                        
+
             tile_basename = os.path.basename(os.path.splitext(t.name)[0])                                    
             logger.info("Number of contributors to subtile %s: %i", tile_basename, len(intersects))
-            itpath = os.path.join(mosaic_dir,tile_basename+"_intersects.txt")
-            it = open(itpath,"w")
+            itpath = os.path.join(mosaic_dir, tile_basename + "_intersects.txt")
+            it = open(itpath, "w")
             it.write("\n".join(intersects))
             it.close()
             
@@ -556,7 +562,6 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             logger.info("No tasks to process")
        
 
-
 def build_shp(contribs, shp, args, params):
     logger.info("Creating shapefile of image boundaries: %s", shp)
     
@@ -586,7 +591,7 @@ def build_shp(contribs, shp, args, params):
             ("STATS_PXCT", ogr.OFTString, 80)
         )
     
-    if (params.median_remove is True): 
+    if params.median_remove is True:
         fields = fields + (
             ("MEDIAN", ogr.OFTString, 80),
         )
@@ -623,7 +628,7 @@ def build_shp(contribs, shp, args, params):
         if lyr.CreateField(field_defn) != 0:
             logger.info("ERROR: Failed to create field: %s", fld)
     
-    for iinfo,geom in contribs:
+    for iinfo, geom in contribs:
                 
         feat = ogr.Feature(lyr.GetLayerDefn())
         
@@ -632,7 +637,7 @@ def build_shp(contribs, shp, args, params):
         feat.SetField("ACQDATE", iinfo.acqdate.strftime("%Y-%m-%d"))
         feat.SetField("CAT_ID", iinfo.catid)
         feat.SetField("OFF_NADIR", iinfo.ona)
-        feat.SetField("SUN_ELEV" ,iinfo.sunel)
+        feat.SetField("SUN_ELEV", iinfo.sunel)
         feat.SetField("SUN_AZ", iinfo.sunaz)
         feat.SetField("SAT_ELEV", iinfo.satel)
         feat.SetField("SAT_AZ", iinfo.sataz)
@@ -672,7 +677,7 @@ def build_shp(contribs, shp, args, params):
                 feat.SetField("STATS_STD", ",".join(stdev_list))
                 feat.SetField("STATS_PXCT", ",".join(px_cnt_list))
 
-        if (params.median_remove is True):
+        if params.median_remove is True:
             median_list = []
             keys = iinfo.median.keys()
             keys.sort()
@@ -695,12 +700,12 @@ def build_tiles_shp(mosaicname, tiles, params):
     else:
         logger.info("Creating shapefile of tiles: %s", os.path.basename(tiles_shp))
         fields = [('ROW', ogr.OFTInteger, 4),
-                ('COL', ogr.OFTInteger, 4),
-                ("TILENAME", ogr.OFTString, 100),
-                ('XMIN', ogr.OFTReal, 0),
-                ('XMAX', ogr.OFTReal, 0),
-                ('YMIN', ogr.OFTReal, 0),
-                ('YMAX', ogr.OFTReal, 0)]
+                  ('COL', ogr.OFTInteger, 4),
+                  ("TILENAME", ogr.OFTString, 100),
+                  ('XMIN', ogr.OFTReal, 0),
+                  ('XMAX', ogr.OFTReal, 0),
+                  ('YMIN', ogr.OFTReal, 0),
+                  ('YMAX', ogr.OFTReal, 0)]
                   
         OGR_DRIVER = "ESRI Shapefile"
         ogrDriver = ogr.GetDriverByName(OGR_DRIVER)
@@ -735,13 +740,13 @@ def build_tiles_shp(mosaicname, tiles, params):
         
         for t in tiles:
             feat = ogr.Feature(lyr.GetLayerDefn())
-            feat.SetField("TILENAME",os.path.basename(t.name))
-            feat.SetField("ROW",t.j)
-            feat.SetField("COL",t.i)
-            feat.SetField("XMIN",t.xmin)
-            feat.SetField("XMAX",t.xmax)
-            feat.SetField("YMIN",t.ymin)
-            feat.SetField("YMAX",t.ymax)
+            feat.SetField("TILENAME", os.path.basename(t.name))
+            feat.SetField("ROW", t.j)
+            feat.SetField("COL", t.i)
+            feat.SetField("XMIN", t.xmin)
+            feat.SetField("XMAX", t.xmax)
+            feat.SetField("YMIN", t.ymin)
+            feat.SetField("YMAX", t.ymax)
             feat.SetGeometry(t.geom)
             
             if lyr.CreateFeature(feat) != 0:

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -678,7 +678,6 @@ def build_shp(contribs, shp, args, params):
                 feat.SetField("STATS_PXCT", ",".join(px_cnt_list))
 
         if params.median_remove is True:
-            median_list = []
             keys = iinfo.median.keys()
             keys.sort()
             median_list = [str(iinfo.median[band]) for band in keys]

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -92,7 +92,7 @@ def main():
                 if len(median) == iinfo.bands:
                     iinfo.set_raster_median(median)
                 else:
-                    logger.warning("Median dct length ({}) does not match band count ({})".format(len(median),iinfo.bands))
+                    logger.warning("Median dct length (%i) does not match band count (%i)", len(median), iinfo.bands)
             
             else:
                 iinfo = mosaic.ImageInfo(line,"IMAGE")
@@ -100,11 +100,11 @@ def main():
             intersects.append(iinfo)
         t.close()
     else:
-        logger.error("Intersecting image file does not exist: {}".format(inpath))
+        logger.error("Intersecting image file does not exist: %i", inpath)
 
     logger.info(tile)
 
-    logger.info("Number of image found in source file: {}".format(len(intersects)))
+    logger.info("Number of image found in source file: %i", len(intersects))
     
     wd = os.path.join(localpath,os.path.splitext(os.path.basename(tile))[0])
     if not os.path.isdir(wd):
@@ -137,7 +137,7 @@ def main():
             dst = os.path.join(wd,os.path.basename(mergefile)[:-4])+"_median_removed.tif"
             status = BandSubtractMedian(iinfo,dst)
             if status == 1:
-                logger.error("BandSubtractMedian() failed on {}".format(mergefile))
+                logger.error("BandSubtractMedian() failed on %s", mergefile)
                 sys.exit(1)
             ds = gdal.Open(dst)
             if ds:
@@ -145,7 +145,7 @@ def main():
                 srcnodata = string.join(([str(srcnodata_val)] * bands)," ")
                 mergefile = dst
             else:
-                logger.error("BandSubtractMedian() failed at gdal.Open({})".format(dst))
+                logger.error("BandSubtractMedian() failed at gdal.Open(%s)", dst)
                 sys.exit(1)
             
         if c == 0:
@@ -222,12 +222,12 @@ def BandSubtractMedian(iinfo,dstfp):
         driver = gdal.GetDriverByName('GTiff')
         out_ds = driver.Create(dstfp,iinfo.xsize,iinfo.ysize,iinfo.bands,out_datatype,gtiff_options)
         if not out_ds:
-            logger.error("BandSubtractMedian(): !driver.Create({})".format(dstfp))
+            logger.error("BandSubtractMedian(): !driver.Create(%s)", dstfp)
             return 1
         
         ds = gdal.Open(iinfo.srcfp)
         if not ds:
-            logger.error("BandSubtractMedian(): !gdal.Open({})".format(iinfo.srcfp))
+            logger.error("BandSubtractMedian(): !gdal.Open(%s)", iinfo.srcfp)
             return 1
         
         out_ds.SetGeoTransform(ds.GetGeoTransform())
@@ -248,7 +248,7 @@ def BandSubtractMedian(iinfo,dstfp):
                 band_nodata = band_data.GetNoDataValue()
                 # default nodata to zero
                 if band_nodata is None:
-                    logger.info("Defaulting band {} nodata to zero".format(band))
+                    logger.info("Defaulting band %i nodata to zero", band)
                     band_nodata = 0.0 
                 band_array = numpy.array(band_data.ReadAsArray())
                 nodata_mask = (band_array==band_nodata)
@@ -272,7 +272,7 @@ def BandSubtractMedian(iinfo,dstfp):
                 out_band.SetNoDataValue(out_nodataval)
 
             else:
-                logger.error("BandSubtractMedian(): iinfo.median[{}] is None, image {}".format(band,iinfo.srcfp))
+                logger.error("BandSubtractMedian(): iinfo.median[%i] is None, image %s", band, iinfo.srcfp)
                 return 1
         ds = None
         out_ds = None
@@ -282,7 +282,7 @@ def BandSubtractMedian(iinfo,dstfp):
     # taskhandler.exec_cmd(cmd)
 
     else:
-        logger.info("BandSubtractMedian(): {} exists".format(dstfp))
+        logger.info("BandSubtractMedian(): %s exists", dstfp)
 
     return 0
 

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -1,9 +1,4 @@
 import os, sys, shutil, glob, re, tarfile, logging, argparse
-from datetime import datetime, timedelta
-
-from subprocess import *
-from math import *
-from xml.etree import cElementTree as ET
 
 from lib import mosaic, utils, taskhandler
 import numpy

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -56,7 +56,7 @@ def main():
     tile = args.tile
     ref_xres, ref_yres = args.resolution
     xmin,xmax,ymin,ymax = args.extent
-    dims = "-tr %s %s -te %s %s %s %s" %(ref_xres,ref_yres,xmin,ymin,xmax,ymax)
+    dims = "-tr {} {} -te {} {} {} {}".format(ref_xres, ref_yres, xmin, ymin, xmax, ymax)
     
     ##### Configure Logger
     logfile = os.path.splitext(tile)[0]+".log"
@@ -116,7 +116,8 @@ def main():
     images = {}
         
     #### Get Extent geometry 
-    poly_wkt = 'POLYGON (( %s %s, %s %s, %s %s, %s %s, %s %s ))' %(xmin,ymin,xmin,ymax,xmax,ymax,xmax,ymin,xmin,ymin)
+    poly_wkt = 'POLYGON (( {} {}, {} {}, {} {}, {} {}, {} {} ))'.format(xmin, ymin, xmin, ymax, xmax, ymax, xmax, ymin,
+                                                                        xmin, ymin)
     tile_geom = ogr.CreateGeometryFromWkt(poly_wkt)
     
     c = 0
@@ -156,11 +157,12 @@ def main():
                 logger.info("localtile1 already exists")
                 status = 1
                 break
-            cmd = 'gdalwarp %s -srcnodata "%s" -dstnodata "%s" "%s" "%s"' %(dims,srcnodata,srcnodata,mergefile,localtile1)
+            cmd = 'gdalwarp {} -srcnodata "{}" -dstnodata "{}" "{}" "{}"'.format(dims, srcnodata, srcnodata, mergefile,
+                                                                                 localtile1)
             taskhandler.exec_cmd(cmd)
             
         else:
-            cmd = 'gdalwarp -srcnodata "%s" "%s" "%s"' %(srcnodata,mergefile,localtile1)
+            cmd = 'gdalwarp -srcnodata "{}" "{}" "{}"'.format(srcnodata, mergefile, localtile1)
             taskhandler.exec_cmd(cmd)
             
         c += 1
@@ -178,12 +180,13 @@ def main():
             elif args.gtiff_compression == 'jpeg95':
                 compress_option =  '-co "compress=jpeg" -co "jpeg_quality=95"'
                 
-            cmd = 'gdal_translate -stats -of GTiff %s -co "PHOTOMETRIC=MINISBLACK" -co "TILED=YES" -co "BIGTIFF=IF_SAFER" "%s" "%s"' %(compress_option,localtile1,localtile2)
+            cmd = 'gdal_translate -stats -of GTiff {} -co "PHOTOMETRIC=MINISBLACK" -co "TILED=YES" -co ' \
+                  '"BIGTIFF=IF_SAFER" "{}" "{}"'.format(compress_option, localtile1, localtile2)
             taskhandler.exec_cmd(cmd)
         
         ####  Build Pyramids        
         if os.path.isfile(localtile2):
-            cmd = 'gdaladdo "%s" 2 4 8 16 30' %(localtile2)
+            cmd = 'gdaladdo "{}" 2 4 8 16 30'.format(localtile2)
             taskhandler.exec_cmd(cmd)
         
         #### Copy tile to destination
@@ -265,11 +268,11 @@ def BandSubtractMedian(iinfo,dstfp):
                     band_min = numpy.min(band_valid)
                     corr_min = numpy.subtract(float(band_min),float(band_median))
                     if( corr_min < float(out_min) ):
-                        logger.error("BandSubtractMedian() returns min out of range for {} band {}".format(iinfo.srcfp,band))
+                        logger.error("BandSubtractMedian() returns min out of range for %s band %i", iinfo.srcfp, band)
                         return 1
                     band_corrected[~nodata_mask] = numpy.subtract(band_array[~nodata_mask],band_median)
                 else:
-                    logger.warning("Band {} has no valid data".format(band))
+                    logger.warning("Band %i has no valid data", band)
                 out_band = out_ds.GetRasterBand(band)
                 out_band.WriteArray(band_corrected)
                 out_band.SetNoDataValue(out_nodataval)

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -1,4 +1,4 @@
-import os, string, sys, shutil, glob, re, tarfile, logging, argparse
+import os, sys, shutil, glob, re, tarfile, logging, argparse
 from datetime import datetime, timedelta
 
 from subprocess import *
@@ -44,7 +44,7 @@ def main():
     parser.add_argument("--wd",
                         help="scratch space (default is mosaic directory)")
     parser.add_argument("--gtiff-compression", choices=mosaic.GTIFF_COMPRESSIONS, default="lzw",
-                        help="GTiff compression type. Default=lzw (%s)"%string.join(mosaic.GTIFF_COMPRESSIONS,','))
+                        help="GTiff compression type. Default=lzw ({})".format(','.join(mosaic.GTIFF_COMPRESSIONS)))
     
     #### Parse Arguments
     args = parser.parse_args()
@@ -128,7 +128,10 @@ def main():
         if args.force_pan_to_multi and iinfo.bands > 1:
             if iinfo.bands == 1:
                 mergefile = os.path.join(wd,os.path.basename(iinfo.srcfp)[:-4])+"_merge.tif"
-                cmd = 'gdal_merge.py -ps %s %s -separate -o "%s" "%s"' %(ref_xres, ref_yres, mergefile, string.join(([iinfo.srcfp] * iinfo.bands),'" "'))
+                cmd = 'gdal_merge.py -ps {} {} -separate -o "{}" "{}"'.format(ref_xres,
+                                                                              ref_yres,
+                                                                              mergefile,
+                                                                              '" "'.join([iinfo.srcfp] * iinfo.bands))
                 taskhandler.exec_cmd(cmd)
         srcnodata = " ".join([str(ndv) for ndv in iinfo.nodatavalue])
 
@@ -142,7 +145,7 @@ def main():
             ds = gdal.Open(dst)
             if ds:
                 srcnodata_val = ds.GetRasterBand(1).GetNoDataValue()
-                srcnodata = string.join(([str(srcnodata_val)] * bands)," ")
+                srcnodata = " ".join([str(srcnodata_val)] * bands)
                 mergefile = dst
             else:
                 logger.error("BandSubtractMedian() failed at gdal.Open(%s)", dst)

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -115,7 +115,6 @@ def main():
     #### Get Extent geometry 
     poly_wkt = 'POLYGON (( {} {}, {} {}, {} {}, {} {}, {} {} ))'.format(xmin, ymin, xmin, ymax, xmax, ymax, xmax, ymin,
                                                                         xmin, ymin)
-    tile_geom = ogr.CreateGeometryFromWkt(poly_wkt)
     
     c = 0
     for iinfo in intersects:
@@ -134,7 +133,6 @@ def main():
         srcnodata = " ".join([str(ndv) for ndv in iinfo.nodatavalue])
 
         if args.median_remove:
-            src = mergefile
             dst = os.path.join(wd, os.path.basename(mergefile)[:-4]) + "_median_removed.tif"
             status = BandSubtractMedian(iinfo, dst)
             if status == 1:

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -235,10 +235,10 @@ def BandSubtractMedian(iinfo, dstfp):
         
         ## check if median was passed in, calculate if not
         try:
-            keys = iinfo.median.keys()
+            keys = list(iinfo.median.keys())
         except KeyError:
             iinfo.get_raster_median()
-            keys = iinfo.median.keys()
+            keys = list(iinfo.median.keys())
         
         keys.sort()
         for band in keys:

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -146,7 +146,7 @@ def main():
     else:
         exclude_list = set()
     
-    logger.debug("Exclude list: %s" %str(exclude_list))
+    logger.debug("Exclude list: %s", str(exclude_list))
     
     #### Parse csv, validate tile ID and get tilegeom
     tiles = {}
@@ -154,7 +154,7 @@ def main():
     for line in csv:
         tile = line.rstrip().split(",")
         if len(tile) != 9:
-            logger.warning("funny csv line: %s" %line.strip('\n'))
+            logger.warning("funny csv line: %s", line.strip('\n'))
         else:
             name = tile[2]
             if name != "name":
@@ -173,12 +173,12 @@ def main():
     
         for ttile in ttiles:
             if ttile not in tiles:
-                logger.info("Target tile is not in the tile csv: %s" %ttile)
+                logger.info("Target tile is not in the tile csv: %s", ttile)
                 
             else:
                 t = tiles[ttile]
                 if t.status == "0":
-                    logger.error("Tile status indicates it should not be created: %s, %s" %(ttile,t.status))
+                    logger.error("Tile status indicates it should not be created: %s, %s", ttile,t.status)
                 else:
                     try:
                         HandleTile(t,src,dstdir,csvpath,args,exclude_list)
@@ -204,9 +204,9 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
     mtxtpath = os.path.join(dstdir,"%s_%s_ortho.txt" %(os.path.basename(csvpath)[:-4],t.name))
     
     if os.path.isfile(otxtpath) and os.path.isfile(mtxtpath) and args.overwrite is False:
-        logger.info("Tile %s processing files already exist" %t.name)
+        logger.info("Tile %s processing files already exist", t.name)
     else:
-        logger.info("Tile %s" %(t.name))
+        logger.info("Tile %s", t.name)
     
         t_srs = osr.SpatialReference()
         t_srs.ImportFromEPSG(t.epsg)
@@ -261,10 +261,11 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                         if iinfo.geom.Intersects(t.geom):
                             
                             if iinfo.scene_id in exclude_list:
-                                logger.debug("Scene in exclude list, excluding: %s" %iinfo.srcfp)
+                                logger.debug("Scene in exclude list, excluding: %s", iinfo.srcfp)
                                 
                             elif not os.path.isfile(iinfo.srcfp):
-                                logger.warning("Scene path is invalid, excluding {} (path = {})".format(iinfo.scene_id,iinfo.srcfp))
+                                logger.warning("Scene path is invalid, excluding %s (path = %s)", iinfo.scene_id,
+                                               iinfo.srcfp)
                             elif args.require_pan:
                                 srcfp = iinfo.srcfp
                                 srcdir, mul_name = os.path.split(srcfp)
@@ -281,7 +282,8 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                                               pan_name = os.path.basename(candidates2[0])
                                           else:
                                               pan_name = ''
-                                              logger.error('{} panchromatic images match the multispectral image name {}'.format(len(candidates2),mul_name))
+                                              logger.error('%i panchromatic images match the multispectral image name '
+                                                           '%s', len(candidates2), mul_name)
                                      else:
                                           pan_name = mul_name.replace("-M","-P")
                                 elif iinfo.sensor == "IK01":
@@ -290,20 +292,21 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                                      pan_name = mul_name.replace("bgrn","pan")    
                                 pan_srcfp = os.path.join(srcdir,pan_name)
                                 if not os.path.isfile(pan_srcfp):
-                                     logger.debug("Image does not have a panchromatic component, excluding: %s" %iinfo.srcfp)
+                                     logger.debug("Image does not have a panchromatic component, excluding: %s",
+                                                  iinfo.srcfp)
                                 else:
-                                     logger.debug( "Intersect %s, %s: %s" %(iinfo.scene_id, iinfo.srcfp, str(iinfo.geom)))
+                                     logger.debug("Intersect %s, %s: %s", iinfo.scene_id, iinfo.srcfp, str(iinfo.geom))
                                      imginfo_list1.append(iinfo)
                                 
                             else:
-                                logger.debug( "Intersect %s, %s: %s" %(iinfo.scene_id, iinfo.srcfp, str(iinfo.geom)))
+                                logger.debug( "Intersect %s, %s: %s", iinfo.scene_id, iinfo.srcfp, str(iinfo.geom))
                                 imginfo_list1.append(iinfo)                                
                                 
                     feat = lyr.GetNextFeature()
             
             ds = None
         
-            logger.info("Number of intersects in tile %s: %i" %(t.name,len(imginfo_list1)))
+            logger.info("Number of intersects in tile %s: %i", t.name, len(imginfo_list1))
             
             if len(imginfo_list1) > 0:
                 
@@ -315,7 +318,7 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                 #### Remove images that do not match ref
                 logger.debug("Setting image pattern filter")
                 imginfo_list2 = mosaic.filterMatchingImages(imginfo_list1,params)
-                logger.info("Number of images matching filter: %i" %(len(imginfo_list2)))
+                logger.info("Number of images matching filter: %i", len(imginfo_list2))
                     
                 if args.nosort is False:    
                     #### Sort by quality
@@ -337,7 +340,7 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                 logger.debug("Overlaying images to determine contributors")
                 contribs = mosaic.determine_contributors(imginfo_list3,t.geom,args.min_contribution_area)
                                             
-                logger.info("Number of contributing images: %i" %(len(contribs)))      
+                logger.info("Number of contributing images: %i", len(contribs))
             
                 if len(contribs) > 0:
                     
@@ -346,9 +349,9 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                         #######################################################
                         #### Create Shp
                         
-                        shp = os.path.join(dstdir,"%s_%s_imagery.shp" %(args.mosaic,t.name))
+                        shp = os.path.join(dstdir,"{}_{}_imagery.shp".format(args.mosaic, t.name))
                    
-                        logger.debug("Creating shapefile of geoms: %s" %shp)
+                        logger.debug("Creating shapefile of geoms: %s", shp)
                     
                         fields = [("IMAGENAME", ogr.OFTString, 100),
                             ("SCORE", ogr.OFTReal, 0)]
@@ -357,7 +360,7 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                         
                         ogrDriver = ogr.GetDriverByName(OGR_DRIVER)
                         if ogrDriver is None:
-                            logger.debug("OGR: Driver %s is not available" % OGR_DRIVER)
+                            logger.debug("OGR: Driver %s is not available", OGR_DRIVER)
                             sys.exit(-1)
                         
                         if os.path.isfile(shp):
@@ -372,7 +375,7 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                         
                         lyr = vds.CreateLayer(shpbn, t_srs, ogr.wkbPolygon)
                         if lyr is None:
-                            logger.debug("ERROR: Failed to create layer: %s" % shpbn)
+                            logger.debug("ERROR: Failed to create layer: %s", shpbn)
                             sys.exit(-1)
                         
                         for fld, fdef, flen in fields:
@@ -380,11 +383,11 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                             if fdef == ogr.OFTString:
                                 field_defn.SetWidth(flen)
                             if lyr.CreateField(field_defn) != 0:
-                                logger.debug("ERROR: Failed to create field: %s" % fld)
+                                logger.debug("ERROR: Failed to create field: %s", fld)
                         
                         for iinfo, geom in contribs:
                         
-                            logger.debug("Image: %s" %(iinfo.srcfn))
+                            logger.debug("Image: %s", iinfo.srcfn)
                             
                             feat = ogr.Feature(lyr.GetLayerDefn())
                             
@@ -393,9 +396,9 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
     
                             feat.SetGeometry(geom)
                             if lyr.CreateFeature(feat) != 0:
-                                logger.debug("ERROR: Could not create feature for image %s" % iinfo.srcfn)
+                                logger.debug("ERROR: Could not create feature for image %s", iinfo.srcfn)
                             else:
-                                logger.debug("Created feature for image: %s" %iinfo.srcfn)
+                                logger.debug("Created feature for image: %s", iinfo.srcfn)
                                 
                             feat.Destroy()
                     
@@ -403,17 +406,17 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                     if not os.path.isdir(dstdir):
                         os.makedirs(dstdir)
                     
-                    otxtpath = os.path.join(dstdir,"%s_%s_orig.txt" %(args.mosaic,t.name))
-                    mtxtpath = os.path.join(dstdir,"%s_%s_ortho.txt" %(args.mosaic,t.name))
+                    otxtpath = os.path.join(dstdir, "{}_{}_orig.txt".format(args.mosaic, t.name))
+                    mtxtpath = os.path.join(dstdir, "{}_{}_ortho.txt".format(args.mosaic, t.name))
                     otxt = open(otxtpath,'w')
                     mtxt = open(mtxtpath,'w')
                     
                     for iinfo, geom in contribs:
                         
                         if not os.path.isfile(iinfo.srcfp):
-                            logger.warning("Image does not exist: %s" %(iinfo.srcfp))
+                            logger.warning("Image does not exist: %s", iinfo.srcfp)
                             
-                        otxt.write("%s\n" %iinfo.srcfp)
+                        otxt.write("{}\n".format(iinfo.srcfp))
                         m_fn = "{0}_u08{1}{2}.tif".format(
                             os.path.splitext(iinfo.srcfn)[0],
                             args.stretch,

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -270,33 +270,33 @@ def HandleTile(t,src,dstdir,csvpath,args,exclude_list):
                                 srcfp = iinfo.srcfp
                                 srcdir, mul_name = os.path.split(srcfp)
                                 if iinfo.sensor in ["WV02","WV03","QB02"]:
-                                     pan_name = mul_name.replace("-M","-P")
+                                    pan_name = mul_name.replace("-M","-P")
                                 elif iinfo.sensor == "GE01":
-                                     if "_5V" in mul_name:
-                                          pan_name_base = srcfp[:-24].replace("M0","P0")
-                                          candidates = glob.glob(pan_name_base + "*")
-                                          candidates2 = [f for f in candidates if f.endswith(('.ntf','.NTF','.tif','.TIF'))]
-                                          if len(candidates2) == 0:
-                                              pan_name = ''
-                                          elif len(candidates2) == 1:
-                                              pan_name = os.path.basename(candidates2[0])
-                                          else:
-                                              pan_name = ''
-                                              logger.error('%i panchromatic images match the multispectral image name '
-                                                           '%s', len(candidates2), mul_name)
-                                     else:
-                                          pan_name = mul_name.replace("-M","-P")
+                                    if "_5V" in mul_name:
+                                        pan_name_base = srcfp[:-24].replace("M0","P0")
+                                        candidates = glob.glob(pan_name_base + "*")
+                                        candidates2 = [f for f in candidates if f.endswith(('.ntf','.NTF','.tif','.TIF'))]
+                                        if len(candidates2) == 0:
+                                            pan_name = ''
+                                        elif len(candidates2) == 1:
+                                            pan_name = os.path.basename(candidates2[0])
+                                        else:
+                                            pan_name = ''
+                                            logger.error('%i panchromatic images match the multispectral image name '
+                                                         '%s', len(candidates2), mul_name)
+                                    else:
+                                        pan_name = mul_name.replace("-M","-P")
                                 elif iinfo.sensor == "IK01":
-                                     pan_name = mul_name.replace("blu","pan")
-                                     pan_name = mul_name.replace("msi","pan")
-                                     pan_name = mul_name.replace("bgrn","pan")    
+                                    pan_name = mul_name.replace("blu","pan")
+                                    pan_name = mul_name.replace("msi","pan")
+                                    pan_name = mul_name.replace("bgrn","pan")
                                 pan_srcfp = os.path.join(srcdir,pan_name)
                                 if not os.path.isfile(pan_srcfp):
-                                     logger.debug("Image does not have a panchromatic component, excluding: %s",
-                                                  iinfo.srcfp)
+                                    logger.debug("Image does not have a panchromatic component, excluding: %s",
+                                                 iinfo.srcfp)
                                 else:
-                                     logger.debug("Intersect %s, %s: %s", iinfo.scene_id, iinfo.srcfp, str(iinfo.geom))
-                                     imginfo_list1.append(iinfo)
+                                    logger.debug("Intersect %s, %s: %s", iinfo.scene_id, iinfo.srcfp, str(iinfo.geom))
+                                    imginfo_list1.append(iinfo)
                                 
                             else:
                                 logger.debug( "Intersect %s, %s: %s", iinfo.scene_id, iinfo.srcfp, str(iinfo.geom))

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -1,4 +1,4 @@
-import os, string, sys, logging, argparse, numpy, glob
+import os, sys, logging, argparse, numpy, glob
 from datetime import datetime, date
 import gdal, ogr, osr, gdalconst
 

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -68,7 +68,7 @@ def main():
     #### Validate Required Arguments
     try:
         dsp, lyrn = utils.get_source_names(src)
-    except RuntimeError, e:
+    except RuntimeError as e:
         parser.error(e)
     if not os.path.isfile(csvpath):
         parser.error("Arg2 is not a valid file path: %s" %csvpath)
@@ -182,7 +182,7 @@ def main():
                 else:
                     try:
                         HandleTile(t,src,dstdir,csvpath,args,exclude_list)
-                    except RuntimeError,e:
+                    except RuntimeError as e:
                         logger.error(e)
     
     else:
@@ -193,7 +193,7 @@ def main():
             if t.status == "1":
                 try:
                     HandleTile(t,src,dstdir,csvpath,args,exclude_list)
-                except RuntimeError,e:
+                except RuntimeError as e:
                     logger.error(e)
         
         

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -191,7 +191,7 @@ def main():
                         logger.error(e)
     
     else:
-        keys = tiles.keys()
+        keys = list(tiles.keys())
         keys.sort()
         for tile in keys:
             t = tiles[tile]

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -127,7 +127,7 @@ def main():
             l = "-l {}".format(args.l) if args.l else ""
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -136,7 +136,7 @@ def main():
         elif args.slurm:
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -145,7 +145,7 @@ def main():
         elif args.parallel_processes > 1:
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))
@@ -401,13 +401,13 @@ def calc_ndvi(srcfp, dstfp, args):
                 for f in temp_files:
                     try:
                         os.remove(f)
-                    except Exception, e:
+                    except Exception as e:
                         logger.warning('Could not remove %s: %s' %(os.path.basename(f),e))
             if wd <> dstdir:
                 for f in wd_files:
                     try:
                         os.remove(f)
-                    except Exception, e:
+                    except Exception as e:
                         logger.warning('Could not remove %s: %s' %(os.path.basename(f),e))
         else:
             logger.error("pgc_ndvi.py: {} was not created".dstfp_local)

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -19,25 +19,26 @@ def main():
 
     parser.add_argument("src", help="source image, text file, or directory")
     parser.add_argument("dst", help="destination directory")
-    pos_arg_keys = ["src","dst"]
-    
+    pos_arg_keys = ["src", "dst"]
+
     parser.add_argument("-t", "--outtype", choices=outtypes, default='Float32',
-                    help="output data type (for Int16, output values are scaled from -1000 to 1000)")
+                        help="output data type (for Int16, output values are scaled from -1000 to 1000)")
     parser.add_argument("-s", "--save-temps", action="store_true", default=False,
-                    help="save temp files")
+                        help="save temp files")
     parser.add_argument("--wd",
-                    help="local working directory for cluster jobs (default is dst dir)")
+                        help="local working directory for cluster jobs (default is dst dir)")
     parser.add_argument("--pbs", action='store_true', default=False,
-                    help="submit tasks to PBS")
+                        help="submit tasks to PBS")
     parser.add_argument("--slurm", action='store_true', default=False,
-                    help="submit tasks to SLURM")
+                        help="submit tasks to SLURM")
     parser.add_argument("--parallel-processes", type=int, default=1,
-                    help="number of parallel processes to spawn (default 1)")
+                        help="number of parallel processes to spawn (default 1)")
     parser.add_argument("--qsubscript",
-                    help="submission script to use in PBS/SLURM submission (PBS default is qsub_ndvi.sh, SLURM default is slurm_ndvi.py, in script root folder)")
+                        help="submission script to use in PBS/SLURM submission (PBS default is qsub_ndvi.sh, SLURM "
+                             "default is slurm_ndvi.py, in script root folder)")
     parser.add_argument("-l", help="PBS resources requested (mimicks qsub syntax, PBS only)")
     parser.add_argument("--dryrun", action="store_true", default=False,
-                    help="print actions without executing")
+                        help="print actions without executing")
 
     #### Parse Arguments
     args = parser.parse_args()
@@ -52,7 +53,7 @@ def main():
         srctype = 'textfile'
     elif os.path.isfile(src) and os.path.splitext(src)[1].lower() in ortho_functions.exts:
         srctype = 'image'
-    elif os.path.isfile(src.replace('msi','blu')) and os.path.splitext(src)[1].lower() in ortho_functions.exts:
+    elif os.path.isfile(src.replace('msi', 'blu')) and os.path.splitext(src)[1].lower() in ortho_functions.exts:
         srctype = 'image'
     else:
         parser.error("Error arg1 is not a recognized file path or file type: %s" %(src))
@@ -64,9 +65,9 @@ def main():
     if args.pbs or args.slurm:
         if args.qsubscript is None:
             if args.pbs:
-                qsubpath = os.path.join(os.path.dirname(scriptpath),'qsub_ndvi.sh')
+                qsubpath = os.path.join(os.path.dirname(scriptpath), 'qsub_ndvi.sh')
             if args.slurm:
-                qsubpath = os.path.join(os.path.dirname(scriptpath),'slurm_ndvi.sh')
+                qsubpath = os.path.join(os.path.dirname(scriptpath), 'slurm_ndvi.sh')
         else:
             qsubpath = os.path.abspath(args.qsubscript)
         if not os.path.isfile(qsubpath):
@@ -81,7 +82,7 @@ def main():
     #### Set concole logging handler
     lso = logging.StreamHandler()
     lso.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
     lso.setFormatter(formatter)
     logger.addHandler(lso)
 
@@ -107,7 +108,7 @@ def main():
         dstfp = os.path.join(dstdir, bn + '_ndvi.tif')
         
         if not os.path.isfile(dstfp):
-            i+=1
+            i += 1
             task = taskhandler.Task(
                 srcfn,
                 'NDVI{:04g}'.format(i),
@@ -159,10 +160,10 @@ def main():
                 srcfp, dstfp, task_arg_obj = task.method_arg_list
                 
                 #### Set up processing log handler
-                logfile = os.path.splitext(dstfp)[0]+".log"
+                logfile = os.path.splitext(dstfp)[0] + ".log"
                 lfh = logging.FileHandler(logfile)
                 lfh.setLevel(logging.DEBUG)
-                formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+                formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
                 lfh.setFormatter(formatter)
                 logger.addHandler(lfh)
                 
@@ -173,7 +174,7 @@ def main():
                 logger.removeHandler(lfh)
             
             #### Print Images with Errors    
-            for k,v in results.iteritems():
+            for k, v in results.iteritems():
                 if v != 0:
                     logger.warning("Failed Image: %s", k)
         
@@ -192,11 +193,11 @@ def calc_ndvi(srcfp, dstfp, args):
     tol = 0.00001
 
     # get basenames for src and dst files, get xml metadata filenames
-    srcdir,srcfn = os.path.split(srcfp)
-    dstdir,dstfn = os.path.split(dstfp)
-    bn,ext = os.path.splitext(srcfn)
+    srcdir, srcfn = os.path.split(srcfp)
+    dstdir, dstfn = os.path.split(dstfp)
+    bn, ext = os.path.splitext(srcfn)
     src_xml = os.path.join(srcdir, bn + '.xml')
-    dst_xml = os.path.join(dstdir,bn + '_ndvi.xml')
+    dst_xml = os.path.join(dstdir, bn + '_ndvi.xml')
 
     #### Get working dir
     if args.wd is not None:
@@ -213,7 +214,7 @@ def calc_ndvi(srcfp, dstfp, args):
     print("Image: {}").format(srcfn)
    
     ## copy source image to working directory
-    srcfp_local = os.path.join(wd,srcfn)
+    srcfp_local = os.path.join(wd, srcfn)
     if not os.path.isfile(srcfp_local):
         shutil.copy2(srcfp, srcfp_local)
 
@@ -236,7 +237,7 @@ def calc_ndvi(srcfp, dstfp, args):
 
     ## check for input data type - must be float or int
     datatype = ds.GetRasterBand(1).DataType
-    if not (datatype in [1,2,3,4,5,6,7]):
+    if datatype not in [1, 2, 3, 4, 5, 6, 7]:
         logger.error("Invalid input data type %s", datatype)
         return 1 
 
@@ -246,10 +247,10 @@ def calc_ndvi(srcfp, dstfp, args):
 
     ## open output file for write and copy proj/geotransform info
     if not os.path.isfile(dstfp):
-        dstfp_local = os.path.join(wd,os.path.basename(dstfp))
-        gtiff_options = ['TILED=YES','COMPRESS=LZW','BIGTIFF=IF_SAFER']
+        dstfp_local = os.path.join(wd, os.path.basename(dstfp))
+        gtiff_options = ['TILED=YES', 'COMPRESS=LZW', 'BIGTIFF=IF_SAFER']
         driver = gdal.GetDriverByName('GTiff')
-        out_ds = driver.Create(dstfp_local,nx,ny,1,gdal.GetDataTypeByName(args.outtype),gtiff_options)
+        out_ds = driver.Create(dstfp_local, nx, ny, 1, gdal.GetDataTypeByName(args.outtype), gtiff_options)
         if out_ds:
             out_ds.SetGeoTransform(ds.GetGeoTransform())
             out_ds.SetProjection(ds.GetProjection())
@@ -262,65 +263,65 @@ def calc_ndvi(srcfp, dstfp, args):
         ## for red and nir bands, get band data, nodata values, and natural block size
         ## if NoData is None default it to zero.
         red_band = ds.GetRasterBand(red_band_num)
-        if red_band == None:
+        if red_band is None:
             logger.error("Can't load band %i from %s", red_band_num, srcfp_local)
             return 1
         red_nodata = red_band.GetNoDataValue()
         if red_nodata is None:
             logger.info("Defaulting red band nodata to zero")
             red_nodata = 0.0
-        (red_xblocksize,red_yblocksize) = red_band.GetBlockSize()
+        (red_xblocksize, red_yblocksize) = red_band.GetBlockSize()
     
         nir_band = ds.GetRasterBand(nir_band_num)
-        if nir_band == None:
+        if nir_band is None:
             logger.error("Can't load band %i from %s", nir_band_num, srcfp_local)
             return 1
         nir_nodata = nir_band.GetNoDataValue()
         if nir_nodata is None:
             logger.info("Defaulting nir band nodata to zero")
             nir_nodata = 0.0
-        (nir_xblocksize,nir_yblocksize) = nir_band.GetBlockSize()
+        (nir_xblocksize, nir_yblocksize) = nir_band.GetBlockSize()
 
         ## if different block sizes choose the smaller of the two
-        xblocksize = min([red_xblocksize,nir_xblocksize])
-        yblocksize = min([red_yblocksize,nir_yblocksize])
+        xblocksize = min([red_xblocksize, nir_xblocksize])
+        yblocksize = min([red_yblocksize, nir_yblocksize])
 
         ## calculate the number of x and y blocks to read/write
-        nxblocks = int(math.floor(nx + xblocksize - 1)/xblocksize)
-        nyblocks = int(math.floor(ny + yblocksize - 1)/yblocksize)
+        nxblocks = int(math.floor(nx + xblocksize - 1) / xblocksize)
+        nyblocks = int(math.floor(ny + yblocksize - 1) / yblocksize)
 
         ## blocks loop
         yblockrange = range(nyblocks)
         xblockrange = range(nxblocks)
         for yblock in yblockrange:
             ## y offset for ReadAsArray
-            yoff = yblock*yblocksize
+            yoff = yblock * yblocksize
 
             ## get block actual y size in case of partial block at edge
-            if yblock<nyblocks-1:
-                block_ny=yblocksize
+            if yblock < nyblocks - 1:
+                block_ny = yblocksize
             else:
-                block_ny = ny - (yblock*yblocksize)
+                block_ny = ny - (yblock * yblocksize)
 
             for xblock in xblockrange:
                 ## x offset for ReadAsArray
-                xoff = xblock*xblocksize
+                xoff = xblock * xblocksize
 
                 ## get block actual x size in case of partial block at edge
-                if xblock<(nxblocks-1):
+                if xblock < (nxblocks - 1):
                     block_nx = xblocksize
                 else:
-                    block_nx = nx - (xblock*xblocksize)
+                    block_nx = nx - (xblock * xblocksize)
 
                 ## read a block from each band
-                red_array = red_band.ReadAsArray(xoff,yoff,block_nx,block_ny)
-                nir_array = nir_band.ReadAsArray(xoff,yoff,block_nx,block_ny)
+                red_array = red_band.ReadAsArray(xoff, yoff, block_nx, block_ny)
+                nir_array = nir_band.ReadAsArray(xoff, yoff, block_nx, block_ny)
 
                 ## generate mask for red nodata, nir nodata, and 
                 ## (red+nir) less than tol away from zero
-                red_mask = (red_array==red_nodata)
+                red_mask = (red_array == red_nodata)
                 if red_array[red_mask] != []:
-                    nir_mask = (nir_array==nir_nodata)
+                    nir_mask = (nir_array == nir_nodata)
                     if nir_array[nir_mask] != []:
                         divzero_mask = abs(nir_array + red_array) < tol
                         if red_array[divzero_mask] != []:
@@ -334,7 +335,7 @@ def calc_ndvi(srcfp, dstfp, args):
                         else:
                             ndvi_mask = red_mask
                 else:
-                    nir_mask = (nir_array==nir_nodata)
+                    nir_mask = (nir_array == nir_nodata)
                     if nir_array[nir_mask] != []:
                         divzero_mask = abs(nir_array + red_array) < tol
                         if red_array[divzero_mask] != []:
@@ -344,44 +345,47 @@ def calc_ndvi(srcfp, dstfp, args):
                     else:
                         divzero_mask = abs(nir_array + red_array) < tol
                         if red_array[divzero_mask] != []:
-                           ndvi_mask = divzero_mask
+                            ndvi_mask = divzero_mask
                         else:
-                           ndvi_mask = numpy.full_like(red_array,fill_value=0,dtype=numpy.bool)
+                            ndvi_mask = numpy.full_like(red_array, fill_value=0, dtype=numpy.bool)
 
                 ## declare ndvi array, init to nodata value
-                ndvi_array = numpy.full_like(red_array,fill_value=ndvi_nodata,dtype=numpy.float32)
+                ndvi_array = numpy.full_like(red_array, fill_value=ndvi_nodata, dtype=numpy.float32)
                 ## cast bands to float for calc
-                red_asfloat = numpy.array(red_array,dtype=numpy.float32)
+                red_asfloat = numpy.array(red_array, dtype=numpy.float32)
                 red_array = None
-                nir_asfloat = numpy.array(nir_array,dtype=numpy.float32)
+                nir_asfloat = numpy.array(nir_array, dtype=numpy.float32)
                 nir_array = None
 
                 ## calculate ndvi
                 if ndvi_array[~ndvi_mask] != []:
-                    ndvi_array[~ndvi_mask] = numpy.divide(numpy.subtract(nir_asfloat[~ndvi_mask],red_asfloat[~ndvi_mask]),numpy.add(nir_asfloat[~ndvi_mask],red_asfloat[~ndvi_mask]))
+                    ndvi_array[~ndvi_mask] = numpy.divide(numpy.subtract(nir_asfloat[~ndvi_mask],
+                                                                         red_asfloat[~ndvi_mask]),
+                                                          numpy.add(nir_asfloat[~ndvi_mask],
+                                                                    red_asfloat[~ndvi_mask]))
                 red_asfloat = None
                 nir_asfloat = None
  
                 ## scale and cast to int if outtype integer
                 if args.outtype == 'Int16':
-                    ndvi_scaled = numpy.full_like(ndvi_array,fill_value=ndvi_nodata,dtype=numpy.int16)
+                    ndvi_scaled = numpy.full_like(ndvi_array, fill_value=ndvi_nodata, dtype=numpy.int16)
                     if ndvi_scaled[~ndvi_mask] != []:
-                        ndvi_scaled[~ndvi_mask] = numpy.array(ndvi_array[~ndvi_mask]*1000.0,dtype=numpy.int16)
+                        ndvi_scaled[~ndvi_mask] = numpy.array(ndvi_array[~ndvi_mask]*1000.0, dtype=numpy.int16)
                     ndvi_array = ndvi_scaled
                     ndvi_scaled = None
 
                 ndvi_mask = None
                
                 ## write valid portion of ndvi array to output file
-                ndvi_band.WriteArray(ndvi_array,xoff,yoff)
+                ndvi_band.WriteArray(ndvi_array, xoff, yoff)
                 ndvi_array = None
 
         out_ds = None
-        ds=None
+        ds = None
         
         if os.path.isfile(dstfp_local):
             ## add pyramids
-            cmd = 'gdaladdo "%s" 2 4 8 16' %(dstfp_local)
+            cmd = 'gdaladdo "{}" 2 4 8 16'.format(dstfp_local)
             taskhandler.exec_cmd(cmd)
 
             ## copy to dst
@@ -421,6 +425,7 @@ def calc_ndvi(srcfp, dstfp, args):
             shutil.copy2(src_xml, dst_xml)
             
     return 0
+
 
 if __name__ == '__main__':
     main()

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -210,7 +210,7 @@ def calc_ndvi(srcfp, dstfp, args):
             pass
     logger.info("Working Dir: %s" %wd)
 
-    print "Image: %s" %srcfn
+    print("Image: {}").format(srcfn)
    
     ## copy source image to working directory
     srcfp_local = os.path.join(wd,srcfn)
@@ -385,7 +385,7 @@ def calc_ndvi(srcfp, dstfp, args):
             taskhandler.exec_cmd(cmd)
 
             ## copy to dst
-            if wd <> dstdir:
+            if wd != dstdir:
                 shutil.copy2(dstfp_local, dstfp)
 
             ## copy xml to dst
@@ -403,7 +403,7 @@ def calc_ndvi(srcfp, dstfp, args):
                         os.remove(f)
                     except Exception as e:
                         logger.warning('Could not remove %s: %s' %(os.path.basename(f),e))
-            if wd <> dstdir:
+            if wd != dstdir:
                 for f in wd_files:
                     try:
                         os.remove(f)

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -211,7 +211,7 @@ def calc_ndvi(srcfp, dstfp, args):
             pass
     logger.info("Working Dir: %s", wd)
 
-    print("Image: {}").format(srcfn)
+    print("Image: {}".format(srcfn))
    
     ## copy source image to working directory
     srcfp_local = os.path.join(wd, srcfn)

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -1,6 +1,6 @@
-import os, string, sys, shutil, math, glob, re, tarfile, argparse, subprocess, logging
+import os, sys, shutil, math, glob, re, tarfile, argparse, subprocess, logging
 from datetime import datetime, timedelta
-import gdal, ogr,osr, gdalconst, numpy
+import gdal, ogr, osr, gdalconst, numpy
 
 from lib import ortho_functions, utils, taskhandler
 
@@ -174,7 +174,7 @@ def main():
                 logger.removeHandler(lfh)
             
             #### Print Images with Errors    
-            for k, v in results.iteritems():
+            for k, v in results.items():
                 if v != 0:
                     logger.warning("Failed Image: %s", k)
         

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -96,7 +96,7 @@ def main():
         image_list = utils.find_images(src, True, ortho_functions.exts)
     else:
         image_list = [src]
-    logger.info('Number of src images: %i' %len(image_list))
+    logger.info('Number of src images: %i', len(image_list))
     
     ## Build task queue
     i = 0
@@ -118,7 +118,7 @@ def main():
             )
             task_queue.append(task)
        
-    logger.info('Number of incomplete tasks: {}'.format(i))
+    logger.info('Number of incomplete tasks: %i', i)
     
     ## Run tasks
     if len(task_queue) > 0:
@@ -148,7 +148,7 @@ def main():
             except RuntimeError as e:
                 logger.error(e)
             else:
-                logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))
+                logger.info("Number of child processes to spawn: %i", task_handler.num_processes)
                 if not args.dryrun:
                     task_handler.run_tasks(task_queue)
     
@@ -175,7 +175,7 @@ def main():
             #### Print Images with Errors    
             for k,v in results.iteritems():
                 if v != 0:
-                    logger.warning("Failed Image: {}".format(k)) 
+                    logger.warning("Failed Image: %s", k)
         
         logger.info("Done")
         
@@ -208,7 +208,7 @@ def calc_ndvi(srcfp, dstfp, args):
             os.makedirs(wd)
         except OSError:
             pass
-    logger.info("Working Dir: %s" %wd)
+    logger.info("Working Dir: %s", wd)
 
     print("Image: {}").format(srcfn)
    
@@ -228,16 +228,16 @@ def calc_ndvi(srcfp, dstfp, args):
             red_band_num = 3
             nir_band_num = 4
         else:
-            logger.error("Cannot calculate NDVI from a {} band image: {}".format(bands, srcfp_local))
+            logger.error("Cannot calculate NDVI from a %i band image: %s", bands, srcfp_local)
             return 1
     else:
-        logger.error("Cannot open target image: {}".format(srcfp_local))
+        logger.error("Cannot open target image: %s", srcfp_local)
         return 1
 
     ## check for input data type - must be float or int
     datatype = ds.GetRasterBand(1).DataType
     if not (datatype in [1,2,3,4,5,6,7]):
-        logger.error("Invalid input data type {}".format(datatype))
+        logger.error("Invalid input data type %s", datatype)
         return 1 
 
     ## get the raster dimensions
@@ -256,14 +256,14 @@ def calc_ndvi(srcfp, dstfp, args):
             ndvi_band = out_ds.GetRasterBand(1)
             ndvi_band.SetNoDataValue(float(ndvi_nodata))
         else:
-            logger.error("Couldn't open for write: {}".format(dstfp_local))
+            logger.error("Couldn't open for write: %s", dstfp_local)
             return 1
 
         ## for red and nir bands, get band data, nodata values, and natural block size
         ## if NoData is None default it to zero.
         red_band = ds.GetRasterBand(red_band_num)
         if red_band == None:
-            logger.error("Can't load band {} from {}".format(red_band_num,srcfp_local))
+            logger.error("Can't load band %i from %s", red_band_num, srcfp_local)
             return 1
         red_nodata = red_band.GetNoDataValue()
         if red_nodata is None:
@@ -273,7 +273,7 @@ def calc_ndvi(srcfp, dstfp, args):
     
         nir_band = ds.GetRasterBand(nir_band_num)
         if nir_band == None:
-            logger.error("Can't load band {} from {}".format(nir_band_num,srcfp_local))
+            logger.error("Can't load band %i from %s", nir_band_num, srcfp_local)
             return 1
         nir_nodata = nir_band.GetNoDataValue()
         if nir_nodata is None:
@@ -392,7 +392,7 @@ def calc_ndvi(srcfp, dstfp, args):
             if os.path.isfile(src_xml):
                 shutil.copy2(src_xml, dst_xml)
             else:
-                logger.warning("xml {} not found".format(src_xml))
+                logger.warning("xml %s not found", src_xml)
         
             ## Delete Temp Files
             temp_files = [srcfp_local]
@@ -402,19 +402,19 @@ def calc_ndvi(srcfp, dstfp, args):
                     try:
                         os.remove(f)
                     except Exception as e:
-                        logger.warning('Could not remove %s: %s' %(os.path.basename(f),e))
+                        logger.warning('Could not remove %s: %s', os.path.basename(f), e)
             if wd != dstdir:
                 for f in wd_files:
                     try:
                         os.remove(f)
                     except Exception as e:
-                        logger.warning('Could not remove %s: %s' %(os.path.basename(f),e))
+                        logger.warning('Could not remove %s: %s', os.path.basename(f), e)
         else:
-            logger.error("pgc_ndvi.py: {} was not created".dstfp_local)
+            logger.error("pgc_ndvi.py: %s was not created", dstfp_local)
             return 1 
             
     else:
-        logger.info("pgc_ndvi.py: file {} already exists".format(dstfp))
+        logger.info("pgc_ndvi.py: file %s already exists", dstfp)
         
         ## copy xml to dst if missing
         if not os.path.isfile(dst_xml):

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -56,10 +56,10 @@ def main():
     elif os.path.isfile(src.replace('msi', 'blu')) and os.path.splitext(src)[1].lower() in ortho_functions.exts:
         srctype = 'image'
     else:
-        parser.error("Error arg1 is not a recognized file path or file type: %s" %(src))
+        parser.error("Error arg1 is not a recognized file path or file type: {}".format(src))
 
     if not os.path.isdir(dstdir):
-        parser.error("Error arg2 is not a valid file path: %s" %(dstdir))
+        parser.error("Error arg2 is not a valid file path: {}".format(dstdir))
 
     ## Verify qsubscript
     if args.pbs or args.slurm:
@@ -71,7 +71,7 @@ def main():
         else:
             qsubpath = os.path.abspath(args.qsubscript)
         if not os.path.isfile(qsubpath):
-            parser.error("qsub script path is not valid: %s" %qsubpath)
+            parser.error("qsub script path is not valid: {}".format(qsubpath))
         
     ## Verify processing options do not conflict
     if args.pbs and args.slurm:

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -192,7 +192,7 @@ def main():
                 src, dstfp, task_arg_obj = task.method_arg_list
                 
                 #### Set up processing log handler
-                logfile = os.path.splitext(dstfp)[0]+".log"
+                logfile = os.path.splitext(dstfp)[0] + ".log"
                 lfh = logging.FileHandler(logfile)
                 lfh.setLevel(logging.DEBUG)
                 formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
@@ -206,7 +206,7 @@ def main():
                 logger.removeHandler(lfh)
             
             #### Print Images with Errors    
-            for k, v in results.iteritems():
+            for k, v in results.items():
                 if v != 0:
                     logger.warning("Failed Image: %s", k)
         

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -20,17 +20,18 @@ def main():
     )
 
     parser.add_argument("--pbs", action='store_true', default=False,
-            help="submit tasks to PBS")
+                        help="submit tasks to PBS")
     parser.add_argument("--slurm", action='store_true', default=False,
-            help="submit tasks to SLURM")
+                        help="submit tasks to SLURM")
     parser.add_argument("--parallel-processes", type=int, default=1,
-            help="number of parallel processes to spawn (default 1)")
+                        help="number of parallel processes to spawn (default 1)")
     parser.add_argument("--qsubscript",
-            help="submission script to use in PBS/SLURM submission (PBS default is qsub_ortho.sh, SLURM default is slurm_ortho.py, in script root folder)")
+                        help="submission script to use in PBS/SLURM submission (PBS default is qsub_ortho.sh, SLURM default is "
+                             "slurm_ortho.py, in script root folder)")
     parser.add_argument("-l",
-            help="PBS resources requested (mimicks qsub syntax, PBS only)")
+                        help="PBS resources requested (mimicks qsub syntax, PBS only)")
     parser.add_argument("--dryrun", action='store_true', default=False,
-            help='print actions without executing')
+                        help='print actions without executing')
 
     #### Parse Arguments
     args = parser.parse_args()
@@ -120,7 +121,7 @@ def main():
             image_list2.append(srcfp)
 
     image_list = list(set(image_list2))
-    logger.info('Number of src images: {}'.format(len(image_list)))
+    logger.info('Number of src images: %i', len(image_list))
     
     ## Build task queue
     i = 0
@@ -148,7 +149,7 @@ def main():
             )
             task_queue.append(task)
     
-    logger.info('Number of incomplete tasks: {}'.format(i)) 
+    logger.info('Number of incomplete tasks: %i', i)
     
     ## Run tasks
     if len(task_queue) > 0:
@@ -178,7 +179,7 @@ def main():
             except RuntimeError as e:
                 logger.error(e)
             else:
-                logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))
+                logger.info("Number of child processes to spawn: %i", task_handler.num_processes)
                 if not args.dryrun:
                     task_handler.run_tasks(task_queue)
     
@@ -206,7 +207,7 @@ def main():
             #### Print Images with Errors    
             for k,v in results.iteritems():
                 if v != 0:
-                    logger.warning("Failed Image: {}".format(k))
+                    logger.warning("Failed Image: %s", k)
         
         logger.info("Done")
         

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -1,9 +1,4 @@
-import os, sys, shutil, math, glob, re, tarfile, logging, shlex, argparse, subprocess
-from datetime import datetime, timedelta
-from xml.dom import minidom
-from xml.etree import cElementTree as ET
-import gdal, ogr, osr, gdalconst
-
+import os, sys, logging, argparse
 from lib import ortho_functions, utils, taskhandler
 
 #### Create Loggers

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -2,7 +2,7 @@ import os, string, sys, shutil, math, glob, re, tarfile, logging, shlex, argpars
 from datetime import datetime, timedelta
 from xml.dom import minidom
 from xml.etree import cElementTree as ET
-import gdal, ogr,osr, gdalconst
+import gdal, ogr, osr, gdalconst
 
 from lib import ortho_functions, utils, taskhandler
 

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -74,7 +74,7 @@ def main():
     #### Verify EPSG
     try:
         spatial_ref = utils.SpatialRef(args.epsg)
-    except RuntimeError, e:
+    except RuntimeError as e:
         parser.error(e)
 
     #### Verify that dem and ortho_height are not both specified
@@ -157,7 +157,7 @@ def main():
             l = "-l {}".format(args.l) if args.l else ""
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -166,7 +166,7 @@ def main():
         elif args.slurm:
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -175,7 +175,7 @@ def main():
         elif args.parallel_processes > 1:
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -10,6 +10,7 @@ from lib import ortho_functions, utils, taskhandler
 logger = logging.getLogger("logger")
 logger.setLevel(logging.DEBUG)
 
+
 def main():
 
     #### Set Up Arguments
@@ -26,8 +27,8 @@ def main():
     parser.add_argument("--parallel-processes", type=int, default=1,
                         help="number of parallel processes to spawn (default 1)")
     parser.add_argument("--qsubscript",
-                        help="submission script to use in PBS/SLURM submission (PBS default is qsub_ortho.sh, SLURM default is "
-                             "slurm_ortho.py, in script root folder)")
+                        help="submission script to use in PBS/SLURM submission (PBS default is qsub_ortho.sh, SLURM "
+                             "default is slurm_ortho.py, in script root folder)")
     parser.add_argument("-l",
                         help="PBS resources requested (mimicks qsub syntax, PBS only)")
     parser.add_argument("--dryrun", action='store_true', default=False,
@@ -46,25 +47,25 @@ def main():
         srctype = 'textfile'
     elif os.path.isfile(src) and os.path.splitext(src)[1].lower() in ortho_functions.exts:
         srctype = 'image'
-    elif os.path.isfile(src.replace('msi','blu')) and os.path.splitext(src)[1].lower() in ortho_functions.exts:
+    elif os.path.isfile(src.replace('msi', 'blu')) and os.path.splitext(src)[1].lower() in ortho_functions.exts:
         srctype = 'image'
     else:
-        parser.error("Error arg1 is not a recognized file path or file type: %s" %(src))
+        parser.error("Error arg1 is not a recognized file path or file type: {}".format(src))
 
     if not os.path.isdir(dstdir):
-        parser.error("Error arg2 is not a valid file path: %s" %(dstdir))
+        parser.error("Error arg2 is not a valid file path: {}".format(dstdir))
 
     ## Verify qsubscript
     if args.pbs or args.slurm:
         if args.qsubscript is None:
             if args.pbs:
-                qsubpath = os.path.join(os.path.dirname(scriptpath),'qsub_ortho.sh')
+                qsubpath = os.path.join(os.path.dirname(scriptpath), 'qsub_ortho.sh')
             if args.slurm:
-                qsubpath = os.path.join(os.path.dirname(scriptpath),'slurm_ortho.sh')
+                qsubpath = os.path.join(os.path.dirname(scriptpath), 'slurm_ortho.sh')
         else:
             qsubpath = os.path.abspath(args.qsubscript)
         if not os.path.isfile(qsubpath):
-            parser.error("qsub script path is not valid: %s" %qsubpath)
+            parser.error("qsub script path is not valid: {}".format(qsubpath))
 
     ## Verify processing options do not conflict
     if args.pbs and args.slurm:
@@ -85,12 +86,12 @@ def main():
     #### Test if DEM exists
     if args.dem:
         if not os.path.isfile(args.dem):
-            parser.error("DEM does not exist: %s" %args.dem)
+            parser.error("DEM does not exist: {}".format(args.dem))
 
     #### Set up console logging handler
     lso = logging.StreamHandler()
     lso.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
     lso.setFormatter(formatter)
     logger.addHandler(lso)
 
@@ -109,11 +110,11 @@ def main():
     ## Group Ikonos
     image_list2 = []
     for srcfp in image_list1:
-        srcdir,srcfn = os.path.split(srcfp)
+        srcdir, srcfn = os.path.split(srcfp)
         if "IK01" in srcfn and sum([b in srcfn for b in ortho_functions.ikMsiBands]) > 0:
             for b in ortho_functions.ikMsiBands:
                 if b in srcfn:
-                    newname = os.path.join(srcdir,srcfn.replace(b,"msi"))
+                    newname = os.path.join(srcdir, srcfn.replace(b, "msi"))
                     break
             image_list2.append(newname)
 
@@ -128,7 +129,7 @@ def main():
     task_queue = []
     for srcfp in image_list:
         srcdir, srcfn = os.path.split(srcfp)
-        dstfp = os.path.join(dstdir,"%s_%s%s%d%s" %(
+        dstfp = os.path.join(dstdir, "{}_{}{}{}{}".format(
             os.path.splitext(srcfn)[0],
             utils.get_bit_depth(args.outtype),
             args.stretch,
@@ -194,7 +195,7 @@ def main():
                 logfile = os.path.splitext(dstfp)[0]+".log"
                 lfh = logging.FileHandler(logfile)
                 lfh.setLevel(logging.DEBUG)
-                formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+                formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
                 lfh.setFormatter(formatter)
                 logger.addHandler(lfh)
                 
@@ -205,7 +206,7 @@ def main():
                 logger.removeHandler(lfh)
             
             #### Print Images with Errors    
-            for k,v in results.iteritems():
+            for k, v in results.iteritems():
                 if v != 0:
                     logger.warning("Failed Image: %s", k)
         

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -1,4 +1,4 @@
-import os, string, sys, shutil, math, glob, re, tarfile, logging, shlex, argparse, subprocess
+import os, sys, shutil, math, glob, re, tarfile, logging, shlex, argparse, subprocess
 from datetime import datetime, timedelta
 from xml.dom import minidom
 from xml.etree import cElementTree as ET

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -90,8 +90,8 @@ class ImagePair(object):
                     pan_name = os.path.basename(candidates2[0])
                 else: #raise error for now. TODO: iterate through candidates for greatest overlap
                     pan_name = ''
-                    logger.error('{} panchromatic images match the multispectral image name {}'.format(len(candidates2),
-                                                                                                       self.mul_srcfn))
+                    logger.error('%i panchromatic images match the multispectral image name %s', len(candidates2),
+                                 self.mul_srcfn)
             else:
                 pan_name = self.mul_srcfn.replace("-M","-P")
         elif self.sensor == "IK01":
@@ -180,7 +180,7 @@ class ImagePair(object):
             return extent_geom
                    
         else:
-            logger.error("Cannot open dataset: %s" %src_image)
+            logger.error("Cannot open dataset: %s", src_image)
             return None
 
 
@@ -286,10 +286,10 @@ def main():
         except RuntimeError as e:
             logger.error(e)
         else:
-            logger.info("Image: {}, Sensor: {}".format(image_pair.mul_srcfn, image_pair.sensor))
+            logger.info("Image: %s, Sensor: %s", image_pair.mul_srcfn, image_pair.sensor)
             pair_list.append(image_pair)
                 
-    logger.info('Number of src image pairs: {}'.format(len(pair_list)))
+    logger.info('Number of src image pairs: %i', len(pair_list))
     
     ## Build task queue
     i = 0
@@ -311,7 +311,7 @@ def main():
             )
             task_queue.append(task)
             
-    logger.info('Number of incomplete tasks: {}'.format(i)) 
+    logger.info('Number of incomplete tasks: %i', i)
 
     ## Run tasks
     if len(task_queue) > 0:
@@ -341,7 +341,7 @@ def main():
             except RuntimeError as e:
                 logger.error(e)
             else:
-                logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))
+                logger.info("Number of child processes to spawn: %i", task_handler.num_processes)
                 if not args.dryrun:
                     task_handler.run_tasks(task_queue)
     
@@ -353,7 +353,7 @@ def main():
                 src, dstfp, task_arg_obj = task.method_arg_list
                 
                 #### Set up processing log handler
-                logfile = os.path.splitext(dstfp)[0]+".log"
+                logfile = os.path.splitext(dstfp)[0] + ".log"
                 lfh = logging.FileHandler(logfile)
                 lfh.setLevel(logging.DEBUG)
                 formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
@@ -372,7 +372,7 @@ def main():
             #### Print Images with Errors    
             for k,v in results.items():
                 if v != 0:
-                    logger.warning("Failed Image: {}".format(k))
+                    logger.warning("Failed Image: %s", k)
         
         logger.info("Done")
         
@@ -394,7 +394,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
             os.makedirs(wd)
         except OSError:
             pass
-    logger.info("Working Dir: %s" %wd)
+    logger.info("Working Dir: %s", wd)
 
     ####  Identify name pattern
     print("Multispectral image: {}".format(image_pair.mul_srcfp))
@@ -486,7 +486,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
                 try:
                     os.remove(f)
                 except Exception as e:
-                    logger.warning('Could not remove %s: %s' %(os.path.basename(f),e))
+                    logger.warning('Could not remove %s: %s', os.path.basename(f), e)
     
     if os.path.isfile(pansh_dstfp):
         return 0

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -248,7 +248,7 @@ def main():
     #### Verify EPSG
     try:
         spatial_ref = utils.SpatialRef(args.epsg)
-    except RuntimeError, e:
+    except RuntimeError as e:
         parser.error(e)
         
     ## Check GDAL version (2.1.0 minimum)
@@ -256,7 +256,7 @@ def main():
     try:
         if int(gdal_version) < 2010000:
             parser.error("gdal_pansharpen requires GDAL version 2.1.0 or higher")
-    except ValueError, e:
+    except ValueError:
         parser.error("Cannot parse GDAL version: {}".format(gdal_version))
 
     #### Set up console logging handler
@@ -283,7 +283,7 @@ def main():
         #print(srcfp)
         try:
             image_pair = ImagePair(srcfp, spatial_ref)
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error(e)
         else:
             logger.info("Image: {}, Sensor: {}".format(image_pair.mul_srcfn, image_pair.sensor))
@@ -320,7 +320,7 @@ def main():
             l = "-l {}".format(args.l) if args.l else ""
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -329,7 +329,7 @@ def main():
         elif args.slurm:
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -338,7 +338,7 @@ def main():
         elif args.parallel_processes > 1:
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))
@@ -370,7 +370,7 @@ def main():
                 logger.removeHandler(lfh)
                 
             #### Print Images with Errors    
-            for k,v in results.iteritems():
+            for k,v in results.items():
                 if v != 0:
                     logger.warning("Failed Image: {}".format(k))
         
@@ -464,7 +464,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
     shutil.copy2(mul_xmlfp,pansh_xmlfp)
 
     #### Copy pansharpened output
-    if wd <> dstdir:
+    if wd != dstdir:
         for local_path, dst_path in [
             (pansh_local_dstfp, pansh_dstfp),
             (pan_local_dstfp, pan_dstfp),
@@ -481,11 +481,11 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
     ]
 
     if not args.save_temps:
-        if wd <> dstdir:
+        if wd != dstdir:
             for f in wd_files:
                 try:
                     os.remove(f)
-                except Exception, e:
+                except Exception as e:
                     logger.warning('Could not remove %s: %s' %(os.path.basename(f),e))
     
     if os.path.isfile(pansh_dstfp):

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -64,11 +64,11 @@ class ImagePair(object):
                 mul_extent = self._get_image_info(self.mul_srcfp, spatial_ref)
                 pan_extent = self._get_image_info(self.pan_srcfp, spatial_ref)
                 self.intersection_geom = mul_extent.Intersection(pan_extent)
-                # print mul_extent
-                # print mul_extent.Contains(pan_extent)
-                # print pan_extent
-                # print pan_extent.Contains(mul_extent)
-                # print self.intersection_geom
+                # print(mul_extent)
+                # print(mul_extent.Contains(pan_extent))
+                # print(pan_extent)
+                # print(pan_extent.Contains(mul_extent))
+                # print(self.intersection_geom)
                 
         else:
             raise RuntimeError("Image does not match multispectral name pattern: {}".format(self.mul_srcfn))
@@ -144,7 +144,7 @@ class ImagePair(object):
                 ysize = ds.RasterYSize
                 proj = ds.GetProjectionRef()
                 gtf = ds.GetGeoTransform()
-                print gtf
+                print(gtf)
     
                 ulx = gtf[0] + 0 * gtf[1] + 0 * gtf[2]
                 uly = gtf[3] + 0 * gtf[4] + 0 * gtf[5]
@@ -280,7 +280,7 @@ def main():
 
     pair_list = []
     for srcfp in image_list1:
-        #print  srcfp
+        #print(srcfp)
         try:
             image_pair = ImagePair(srcfp, spatial_ref)
         except RuntimeError, e:
@@ -397,8 +397,8 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
     logger.info("Working Dir: %s" %wd)
 
     ####  Identify name pattern
-    print "Multispectral image: %s" %image_pair.mul_srcfp
-    print "Panchromatic image: %s" %image_pair.pan_srcfp
+    print("Multispectral image: {}".format(image_pair.mul_srcfp))
+    print("Panchromatic image: {}".format(image_pair.pan_srcfp))
 
     if args.dem is not None:
         dem_arg = '-d "%s" ' %args.dem
@@ -453,7 +453,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
             cmd = 'gdal_pansharpen{} -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co TILED=YES "{}" "{}" "{}"'.format(py_ext, pan_local_dstfp, mul_local_dstfp, pansh_local_dstfp)
             taskhandler.exec_cmd(cmd)
     else:
-        print "Pan or Multi warped image does not exist\n\t%s\n\t%s" %(pan_local_dstfp,mul_local_dstfp)
+        print("Pan or Multi warped image does not exist\n\t{}\n\t{}").format(pan_local_dstfp, mul_local_dstfp)
 
     #### Make pyramids
     if os.path.isfile(pansh_local_dstfp):

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -1,4 +1,4 @@
-import os, string, sys, shutil, math, glob, re, tarfile, argparse, subprocess, logging, platform
+import os, sys, shutil, math, glob, re, tarfile, argparse, subprocess, logging, platform
 from datetime import datetime, timedelta
 import gdal, ogr, osr, gdalconst
 

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -404,7 +404,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
     print("Panchromatic image: {}".format(image_pair.pan_srcfp))
 
     if args.dem is not None:
-        dem_arg = '-d "%s" ' %args.dem
+        dem_arg = '-d "{}" '.format(args.dem)
     else:
         dem_arg = ""
 

--- a/tests/func_test_mosaic.py
+++ b/tests/func_test_mosaic.py
@@ -41,8 +41,8 @@ class TestMosaicFunc(unittest.TestCase):
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se,so = p.communicate()
-        # print so
-        # print se
+        # print(so)
+        # print(se)
         
         self.assertTrue(os.path.isfile(mosaicname + '_1_1.tif'))
         self.assertTrue(os.path.isfile(mosaicname + '_1_2.tif'))
@@ -82,8 +82,8 @@ class TestMosaicFunc(unittest.TestCase):
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se, so = p.communicate()
-        # print so
-        # print se
+        # print(so)
+        # print(se)
         
         self.assertTrue(os.path.isfile(mosaicname + '_1_1.tif'))
         self.assertTrue(os.path.isfile(mosaicname + '_1_2.tif'))
@@ -111,8 +111,8 @@ class TestMosaicFunc(unittest.TestCase):
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se, so = p.communicate()
-        # print so
-        # print se
+        # print(so)
+        # print(se)
         
         self.assertTrue(os.path.isfile(mosaicname + '_1_1.tif'))
         self.assertTrue(os.path.isfile(mosaicname + '_1_2.tif'))
@@ -138,8 +138,8 @@ class TestMosaicFunc(unittest.TestCase):
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se, so = p.communicate()
-        # print so
-        # print se
+        # print(so)
+        # print(se)
         
         self.assertTrue(os.path.isfile(mosaicname + '_1_1.tif'))
         self.assertTrue(os.path.isfile(mosaicname + '_1_2.tif'))

--- a/tests/func_test_mosaic.py
+++ b/tests/func_test_mosaic.py
@@ -60,7 +60,7 @@ class TestMosaicFunc(unittest.TestCase):
             mosaicname+'_2_2_intersects.txt':2,
         }
         
-        for f,cnt in intersects_files.iteritems():
+        for f, cnt in intersects_files.items():
             fh = open(f)
             lines = fh.readlines()
             self.assertEqual(len(lines),cnt)

--- a/tests/func_test_mosaic.py
+++ b/tests/func_test_mosaic.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("logger")
 class TestMosaicFunc(unittest.TestCase):
     
     def setUp(self):
-        self.srcdir = os.path.join(os.path.join(test_dir,'mosaic','ortho'))
+        self.srcdir = os.path.join(os.path.join(test_dir, 'mosaic', 'ortho'))
         self.scriptpath = os.path.join(root_dir, "pgc_mosaic.py")
         self.dstdir = os.path.join(script_dir, 'testdata', 'output')
         # if os.path.isdir(self.dstdir):
@@ -39,7 +39,7 @@ class TestMosaicFunc(unittest.TestCase):
             mosaicname,
             args
         )
-        p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se,so = p.communicate()
         # print so
         # print se
@@ -54,20 +54,19 @@ class TestMosaicFunc(unittest.TestCase):
         
         ## test if intersects files have correct number of files
         intersects_files = {
-            mosaicname+'_1_1_intersects.txt':2,
-            mosaicname+'_2_1_intersects.txt':3,
-            mosaicname+'_1_2_intersects.txt':2,
-            mosaicname+'_2_2_intersects.txt':2,
+            mosaicname + '_1_1_intersects.txt': 2,
+            mosaicname + '_2_1_intersects.txt': 3,
+            mosaicname + '_1_2_intersects.txt': 2,
+            mosaicname + '_2_2_intersects.txt': 2,
         }
         
         for f, cnt in intersects_files.items():
             fh = open(f)
             lines = fh.readlines()
-            self.assertEqual(len(lines),cnt)
+            self.assertEqual(len(lines), cnt)
             
         ## TODO test if culines does not have stats and median
-            
-    
+
     #@unittest.skip("skipping")
     def test_bgrn_mosaic_with_stats(self):   
         # extent = -3260000, -3240000, 520000, 540000
@@ -81,8 +80,8 @@ class TestMosaicFunc(unittest.TestCase):
             mosaicname,
             args
         )
-        p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-        se,so = p.communicate()
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        se, so = p.communicate()
         # print so
         # print se
         
@@ -101,7 +100,7 @@ class TestMosaicFunc(unittest.TestCase):
         # extent = -3260000, -3240000, 520000, 540000
         # tilesize = 10000, 10000
         # bands = 1
-        srcdir = os.path.join(os.path.join(test_dir,'mosaic','pansh_ndvi'))
+        srcdir = os.path.join(os.path.join(test_dir, 'mosaic', 'pansh_ndvi'))
         mosaicname = os.path.join(self.dstdir, 'testmosaic3')
         args = '--component-shp -e -3260000 -3240000 520000 540000 -t 10000 10000 -b 1'
         cmd = 'python {} {} {} {}'.format(
@@ -110,8 +109,8 @@ class TestMosaicFunc(unittest.TestCase):
             mosaicname,
             args
         )
-        p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-        se,so = p.communicate()
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        se, so = p.communicate()
         # print so
         # print se
         
@@ -122,14 +121,13 @@ class TestMosaicFunc(unittest.TestCase):
         self.assertTrue(os.path.isfile(mosaicname + '_cutlines.shp'))
         self.assertTrue(os.path.isfile(mosaicname + '_components.shp'))
         self.assertTrue(os.path.isfile(mosaicname + '_tiles.shp'))
-        
-    
+
     #@unittest.skip("skipping")    
     def test_ndvi_pansh_mosaic_with_stats(self):   
         # extent = -3260000, -3240000, 520000, 540000
         # tilesize = 10000, 10000
         # bands = 1
-        srcdir = os.path.join(os.path.join(test_dir,'mosaic','pansh_ndvi'))
+        srcdir = os.path.join(os.path.join(test_dir, 'mosaic', 'pansh_ndvi'))
         mosaicname = os.path.join(self.dstdir, 'testmosaic4')
         args = '--component-shp -e -3260000 -3240000 520000 540000 -t 10000 10000 -b 1 --calc-stats --median-remove'
         cmd = 'python {} {} {} {}'.format(
@@ -138,8 +136,8 @@ class TestMosaicFunc(unittest.TestCase):
             mosaicname,
             args
         )
-        p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-        se,so = p.communicate()
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        se, so = p.communicate()
         # print so
         # print se
         
@@ -150,13 +148,12 @@ class TestMosaicFunc(unittest.TestCase):
         self.assertTrue(os.path.isfile(mosaicname + '_cutlines.shp'))
         self.assertTrue(os.path.isfile(mosaicname + '_components.shp'))
         self.assertTrue(os.path.isfile(mosaicname + '_tiles.shp'))
-        
-        
+
     # def tearDown(self):
     #     shutil.rmtree(self.dstdir)
-        
-    
+
     ## test_mosaic_pbs
+
 
 if __name__ == '__main__':
     
@@ -174,10 +171,10 @@ if __name__ == '__main__':
     if args.testdata:
         test_dir = os.path.abspath(args.testdata)
     else:
-        test_dir = os.path.join(script_dir,'testdata')
+        test_dir = os.path.join(script_dir, 'testdata')
     
     if not os.path.isdir(test_dir):
-        parser.error("Test data folder does not exist: %s" %test_dir)
+        parser.error("Test data folder does not exist: {}".format(test_dir))
         
     test_cases = [
         TestMosaicFunc

--- a/tests/func_test_mosaic.py
+++ b/tests/func_test_mosaic.py
@@ -40,7 +40,7 @@ class TestMosaicFunc(unittest.TestCase):
             args
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        se,so = p.communicate()
+        se, so = p.communicate()
         # print(so)
         # print(se)
         

--- a/tests/func_test_ndvi.py
+++ b/tests/func_test_ndvi.py
@@ -29,15 +29,15 @@ class TestNdviFunc(unittest.TestCase):
     #@unittest.skip("skipping")
     def test_ndvi(self):
         
-        srcdir = os.path.join(os.path.join(test_dir,'ndvi','ortho'))
+        srcdir = os.path.join(os.path.join(test_dir, 'ndvi', 'ortho'))
         
         cmd = 'python {} {} {}'.format(
             self.scriptpath,
             srcdir,
             self.dstdir,
         )
-        p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-        se,so = p.communicate()
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        se, so = p.communicate()
         # print so
         # print se
         
@@ -55,15 +55,15 @@ class TestNdviFunc(unittest.TestCase):
     #@unittest.skip("skipping")
     def test_ndvi_int16(self):
         
-        srcdir = os.path.join(os.path.join(test_dir,'ndvi','ortho'))
+        srcdir = os.path.join(os.path.join(test_dir, 'ndvi', 'ortho'))
         
         cmd = 'python {} {} {} -t Int16'.format(
             self.scriptpath,
             srcdir,
             self.dstdir,
         )
-        p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-        se,so = p.communicate()
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        se, so = p.communicate()
         # print so
         # print se
         
@@ -81,15 +81,15 @@ class TestNdviFunc(unittest.TestCase):
     #@unittest.skip("skipping")
     def test_ndvi_from_pansharp(self):
         
-        srcdir = os.path.join(os.path.join(test_dir,'ndvi','pansh'))
+        srcdir = os.path.join(os.path.join(test_dir, 'ndvi', 'pansh'))
         
         cmd = 'python {} {} {} -t Int16'.format(
             self.scriptpath,
             srcdir,
             self.dstdir,
         )
-        p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-        se,so = p.communicate()
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        se, so = p.communicate()
         # print so
         # print se
         
@@ -102,7 +102,8 @@ class TestNdviFunc(unittest.TestCase):
     
     def tearDown(self):
         shutil.rmtree(self.dstdir)
-   
+
+
 if __name__ == '__main__':
     
     #### Set Up Arguments
@@ -119,10 +120,10 @@ if __name__ == '__main__':
     if args.testdata:
         test_dir = os.path.abspath(args.testdata)
     else:
-        test_dir = os.path.join(script_dir,'testdata')
+        test_dir = os.path.join(script_dir, 'testdata')
     
     if not os.path.isdir(test_dir):
-        parser.error("Test data folder does not exist: %s" %test_dir)
+        parser.error("Test data folder does not exist: {}".format(test_dir))
         
     test_cases = [
         TestNdviFunc

--- a/tests/func_test_ndvi.py
+++ b/tests/func_test_ndvi.py
@@ -38,8 +38,8 @@ class TestNdviFunc(unittest.TestCase):
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se, so = p.communicate()
-        # print so
-        # print se
+        # print(so)
+        # print(se)
         
         for f in os.listdir(srcdir):
             if f.endswith('.tif'):
@@ -64,8 +64,8 @@ class TestNdviFunc(unittest.TestCase):
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se, so = p.communicate()
-        # print so
-        # print se
+        # print(so)
+        # print(se)
         
         for f in os.listdir(srcdir):
             if f.endswith('.tif'):
@@ -90,8 +90,8 @@ class TestNdviFunc(unittest.TestCase):
         )
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         se, so = p.communicate()
-        # print so
-        # print se
+        # print(so)
+        # print(se)
         
         for f in os.listdir(srcdir):
             if f.endswith('.tif'):

--- a/tests/func_test_ortho.py
+++ b/tests/func_test_ortho.py
@@ -116,7 +116,7 @@ class TestOrthoFunc(unittest.TestCase):
         
             # dem: Y:/private/elevation/dem/RAMP/RAMPv2/ RAMPv2_wgs84_200m.tif
             # should fail: the image is not contained within the DEM
-            r"""python "{}" -r 10 --epsg 3413 --dem /mnt/agic/storage00/agic/private/elevation/dem/RAMP/RAMPv2/RAMPv2_wgs84_200m.tif %s/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF {}"""
+            r"""python "{}" -r 10 --epsg 3413 --dem /mnt/agic/storage00/agic/private/elevation/dem/RAMP/RAMPv2/RAMPv2_wgs84_200m.tif {}/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF {}"""
             .format(self.scriptpath, self.srcdir, self.dstdir)
         ]
         

--- a/tests/func_test_ortho.py
+++ b/tests/func_test_ortho.py
@@ -11,7 +11,7 @@ from lib import ortho_functions
 logger = logging.getLogger("logger")
 # lso = logging.StreamHandler()
 # lso.setLevel(logging.ERROR)
-# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
 # lso.setFormatter(formatter)
 # logger.addHandler(lso)
 
@@ -19,7 +19,7 @@ logger = logging.getLogger("logger")
 class TestOrthoFunc(unittest.TestCase):
 
     def setUp(self):
-        self.srcdir = os.path.join(os.path.join(test_dir,'ortho'))
+        self.srcdir = os.path.join(os.path.join(test_dir, 'ortho'))
         self.scriptpath = os.path.join(root_dir, "pgc_ortho.py")
         self.dstdir = os.path.join(script_dir, 'testdata', 'output')
         # if os.path.isdir(self.dstdir):
@@ -35,32 +35,33 @@ class TestOrthoFunc(unittest.TestCase):
         
         test_images = [
             #(image_path, egsg)
-            ('IK01_20010602215300_2001060221531300000010031227_po_387877_blu_0020000.ntf',3338), # tests ikonos metadata with multiple source ids
-            ('WV01_20120326222942_102001001B02FA00_12MAR26222942-P1BS-052596100010_03_P007.NTF',3413),
-            ('WV02_20120719233558_103001001B998D00_12JUL19233558-M1BS-052754253040_01_P001.TIF',3413),
-            ('WV02_20131005052802_10300100278D8500_13OCT05052802-P1BS-500099283010_01_P004.NTF',3031),
-            ('GE01_20110108171314_1016023_5V110108M0010160234A222000100252M_000500940.ntf',26914),
-            ('WV03_20140919212947_104001000227BF00_14SEP19212947-M1BS-500191821040_01_P002.NTF',3413),
-            ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF',3413),
-            ('GE01_20140402211914_1050410010473600_14APR02211914-M1BS-053720734020_01_P003.NTF',3413),
-            ('WV02_20100423190859_1030010005C7AF00_10APR23190859-M2AS_R1C1-052462689010_01_P001.NTF',26910),
-            ('IK01_19991222080400_1999122208040550000011606084_po_82037_pan_0000000.tif',32636),
-            ('IK01_20050319201700_2005031920171340000011627450_po_333838_blu_0000000.ntf',3413),
-            ('QB02_20021009211710_101001000153C800_02OCT09211710-M2AS_R1C1-052075481010_01_P001.tif',3413),
-            ('WV01_20091004222215_1020010009B33500_09OCT04222215-P1BS-052532098020_01_P019.ntf',3031),
-            ('QB02_20070918204906_10100100072E5100_07SEP18204906-M3AS_R1C1-005656156020_01_P001.ntf',3413),
-            ('WV02_20100804230742_1030010006A15800_10AUG04230742-M3DM_R1C3-052672098020_01_P001.tif',3413),
-            ('GE01_11OCT122053047-P1BS-10504100009FD100.ntf',3031), #### GE01 image wth abscalfact in W/m2/um
-            ('GE01_14APR022119147-M1BS-1050410010473600.ntf',3413), #### GE01 image wth abscalfact in W/cm2/nm
+            ('IK01_20010602215300_2001060221531300000010031227_po_387877_blu_0020000.ntf', 3338), # tests ikonos metadata with multiple source ids
+            ('WV01_20120326222942_102001001B02FA00_12MAR26222942-P1BS-052596100010_03_P007.NTF', 3413),
+            ('WV02_20120719233558_103001001B998D00_12JUL19233558-M1BS-052754253040_01_P001.TIF', 3413),
+            ('WV02_20131005052802_10300100278D8500_13OCT05052802-P1BS-500099283010_01_P004.NTF', 3031),
+            ('GE01_20110108171314_1016023_5V110108M0010160234A222000100252M_000500940.ntf', 26914),
+            ('WV03_20140919212947_104001000227BF00_14SEP19212947-M1BS-500191821040_01_P002.NTF', 3413),
+            ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF', 3413),
+            ('GE01_20140402211914_1050410010473600_14APR02211914-M1BS-053720734020_01_P003.NTF', 3413),
+            ('WV02_20100423190859_1030010005C7AF00_10APR23190859-M2AS_R1C1-052462689010_01_P001.NTF', 26910),
+            ('IK01_19991222080400_1999122208040550000011606084_po_82037_pan_0000000.tif', 32636),
+            ('IK01_20050319201700_2005031920171340000011627450_po_333838_blu_0000000.ntf', 3413),
+            ('QB02_20021009211710_101001000153C800_02OCT09211710-M2AS_R1C1-052075481010_01_P001.tif', 3413),
+            ('WV01_20091004222215_1020010009B33500_09OCT04222215-P1BS-052532098020_01_P019.ntf', 3031),
+            ('QB02_20070918204906_10100100072E5100_07SEP18204906-M3AS_R1C1-005656156020_01_P001.ntf', 3413),
+            ('WV02_20100804230742_1030010006A15800_10AUG04230742-M3DM_R1C3-052672098020_01_P001.tif', 3413),
+            ('GE01_11OCT122053047-P1BS-10504100009FD100.ntf', 3031), #### GE01 image wth abscalfact in W/m2/um
+            ('GE01_14APR022119147-M1BS-1050410010473600.ntf', 3413), #### GE01 image wth abscalfact in W/cm2/nm
             
         ]
         
-        for test_image,epsg in test_images:
+        for test_image, epsg in test_images:
             
-            srcfp = os.path.join(self.srcdir,test_image)
-            cmd = r"""python "%s" --wd /local -r 10 -p %d "%s" "%s" """ %(self.scriptpath, epsg, srcfp, self.dstdir)
-            p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-            se,so = p.communicate()
+            srcfp = os.path.join(self.srcdir, test_image)
+            cmd = r"""python "{}" --wd /local -r 10 -p {} "{}" "{}" """.format(self.scriptpath, epsg, srcfp,
+                                                                               self.dstdir)
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+            se, so = p.communicate()
             print(so)
             print(se)
             
@@ -80,7 +81,8 @@ class TestOrthoFunc(unittest.TestCase):
             # outtype: Byte
             # gtiff compression: jpeg95
             # dem: Y:/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif
-            r"""python "%s" -r 10 --epsg 3413 --stretch ns --resample cubic --format GTiff --outtype Byte --gtiff-compression jpeg95 --dem /mnt/agic/storage00/agic/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif %s/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF %s""" % (self.scriptpath, self.srcdir, self.dstdir),
+            r"""python "{}" -r 10 --epsg 3413 --stretch ns --resample cubic --format GTiff --outtype Byte --gtiff-compression jpeg95 --dem /mnt/agic/storage00/agic/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif {}/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF {}"""
+            .format(self.scriptpath, self.srcdir, self.dstdir),
            
             # epsg: 3413
             # stretch: rf
@@ -89,7 +91,8 @@ class TestOrthoFunc(unittest.TestCase):
             # outtype: Byte
             # gtiff compression: lzw
             # dem: Y:/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif
-            r"""python "%s" -r 10 --epsg 3413 --stretch rf --resample near --format ENVI --outtype Byte --gtiff-compression lzw --dem /mnt/agic/storage00/agic/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif %s/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF %s""" % (self.scriptpath, self.srcdir, self.dstdir),
+            r"""python "{}" -r 10 --epsg 3413 --stretch rf --resample near --format ENVI --outtype Byte --gtiff-compression lzw --dem /mnt/agic/storage00/agic/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif {}/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF {}"""
+            .format(self.scriptpath, self.srcdir, self.dstdir),
     
             # epsg: 3413
             # stretch: mr
@@ -98,7 +101,8 @@ class TestOrthoFunc(unittest.TestCase):
             # outtype: Float32
             # gtiff compression: lzw
             # dem: Y:/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif
-            r"""python "%s" -r 10 --epsg 3413 --stretch mr --resample near --format HFA --outtype Float32 --gtiff-compression lzw --dem /mnt/agic/storage00/agic/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif %s/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF %s""" % (self.scriptpath, self.srcdir, self.dstdir),
+            r"""python "{}" -r 10 --epsg 3413 --stretch mr --resample near --format HFA --outtype Float32 --gtiff-compression lzw --dem /mnt/agic/storage00/agic/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif {}/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF {}"""
+            .format(self.scriptpath, self.srcdir, self.dstdir),
     
             # epsg: 3413
             # stretch: rd
@@ -107,16 +111,18 @@ class TestOrthoFunc(unittest.TestCase):
             # outtype: UInt16
             # gtiff compression: lzw
             # dem: None
-            r"""python "%s" -r 10 --epsg 3413 --stretch rd --resample near --format GTiff --outtype UInt16 --gtiff-compression lzw %s/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF %s""" % (self.scriptpath, self.srcdir, self.dstdir),
+            r"""python "{}" -r 10 --epsg 3413 --stretch rd --resample near --format GTiff --outtype UInt16 --gtiff-compression lzw {}/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF {}"""
+            .format(self.scriptpath, self.srcdir, self.dstdir),
         
             # dem: Y:/private/elevation/dem/RAMP/RAMPv2/ RAMPv2_wgs84_200m.tif
             # should fail: the image is not contained within the DEM
-            r"""python "%s" -r 10 --epsg 3413 --dem /mnt/agic/storage00/agic/private/elevation/dem/RAMP/RAMPv2/RAMPv2_wgs84_200m.tif %s/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF %s""" % (self.scriptpath, self.srcdir, self.dstdir)
+            r"""python "{}" -r 10 --epsg 3413 --dem /mnt/agic/storage00/agic/private/elevation/dem/RAMP/RAMPv2/RAMPv2_wgs84_200m.tif %s/QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.NTF {}"""
+            .format(self.scriptpath, self.srcdir, self.dstdir)
         ]
         
         for cmd in cmds:
-            p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
-            se,so = p.communicate()
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+            se, so = p.communicate()
             # print(so)
             # print(se)
             
@@ -140,10 +146,10 @@ if __name__ == '__main__':
     if args.testdata:
         test_dir = os.path.abspath(args.testdata)
     else:
-        test_dir = os.path.join(script_dir,'testdata')
+        test_dir = os.path.join(script_dir, 'testdata')
     
     if not os.path.isdir(test_dir):
-        parser.error("Test data folder does not exist: %s" %test_dir)
+        parser.error("Test data folder does not exist: {}".format(test_dir))
         
     test_cases = [
         TestOrthoFunc

--- a/tests/func_test_ortho.py
+++ b/tests/func_test_ortho.py
@@ -61,8 +61,8 @@ class TestOrthoFunc(unittest.TestCase):
             cmd = r"""python "%s" --wd /local -r 10 -p %d "%s" "%s" """ %(self.scriptpath, epsg, srcfp, self.dstdir)
             p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
             se,so = p.communicate()
-            print so
-            print se
+            print(so)
+            print(se)
             
             
     def test_input_parameters(self):
@@ -117,8 +117,8 @@ class TestOrthoFunc(unittest.TestCase):
         for cmd in cmds:
             p = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell=True)
             se,so = p.communicate()
-            # print so
-            # print se
+            # print(so)
+            # print(se)
             
     # def tearDown(self):
     #     shutil.rmtree(self.dstdir)

--- a/tests/unit_test_mosaic.py
+++ b/tests/unit_test_mosaic.py
@@ -10,7 +10,7 @@ from lib import mosaic
 logger = logging.getLogger("logger")
 # lso = logging.StreamHandler()
 # lso.setLevel(logging.ERROR)
-# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
 # lso.setFormatter(formatter)
 # logger.addHandler(lso)
 
@@ -18,11 +18,11 @@ logger = logging.getLogger("logger")
 class TestMosaicImageInfo(unittest.TestCase):
     
     def setUp(self):
-        self.srcdir = os.path.join(os.path.join(test_dir,'mosaic','ortho'))
+        self.srcdir = os.path.join(os.path.join(test_dir, 'mosaic', 'ortho'))
 
     def test_image_info_ge01(self):
         image = 'GE01_20090707163115_297600_5V090707P0002976004A222012202432M_001529596_u08mr3413.tif'
-        image_info = mosaic.ImageInfo(os.path.join(self.srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(self.srcdir, image), 'IMAGE')
         
         self.assertEqual(image_info.xres, 16.0)
         self.assertEqual(image_info.yres, 16.0)
@@ -39,7 +39,7 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertEqual(image_info.ona, 26.86)
         self.assertEqual(image_info.cloudcover, 0.0)
         self.assertEqual(image_info.tdi, 8.0)
-        self.assertEqual(image_info.panfactor ,1)
+        self.assertEqual(image_info.panfactor, 1)
         #self.assertEqual(image_info.exposure_factor, 0)
         self.assertEqual(image_info.date_diff, -9999)
         self.assertEqual(image_info.year_diff, -9999)
@@ -54,7 +54,7 @@ class TestMosaicImageInfo(unittest.TestCase):
 
     def test_image_info_wv01(self):
         image = 'WV01_20080807153945_1020010003A5AC00_08AUG07153945-P1BS-052060421010_01_P011_u08mr3413.tif'
-        image_info = mosaic.ImageInfo(os.path.join(self.srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(self.srcdir, image), 'IMAGE')
         
         self.assertEqual(image_info.xres, 16.0)
         self.assertEqual(image_info.yres, 16.0)
@@ -71,7 +71,7 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertEqual(image_info.ona, 18.5)
         self.assertEqual(image_info.cloudcover, 0.0)
         self.assertEqual(image_info.tdi, 16.0)
-        self.assertEqual(image_info.panfactor ,1)
+        self.assertEqual(image_info.panfactor, 1)
         #self.assertEqual(image_info.exposure_factor, 0)
         self.assertEqual(image_info.date_diff, -9999)
         self.assertEqual(image_info.year_diff, -9999)
@@ -85,9 +85,9 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertEqual(image_info.datapixelcount_dct, datapixelcount_dct)
     
     def test_image_info_wv02_ndvi(self):
-        srcdir = os.path.join(os.path.join(test_dir,'mosaic','ndvi'))
+        srcdir = os.path.join(os.path.join(test_dir, 'mosaic', 'ndvi'))
         image = 'WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u16rf3413_ndvi.tif'
-        image_info = mosaic.ImageInfo(os.path.join(srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(srcdir, image), 'IMAGE')
         
         self.assertEqual(image_info.xres, 64.0)
         self.assertEqual(image_info.yres, 64.0)
@@ -104,7 +104,7 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertEqual(image_info.ona, 19.4)
         self.assertEqual(image_info.cloudcover, 0.0)
         self.assertEqual(image_info.tdi, 24.0)
-        self.assertEqual(image_info.panfactor ,1)
+        self.assertEqual(image_info.panfactor, 1)
         #self.assertEqual(image_info.exposure_factor, 0)
         self.assertEqual(image_info.date_diff, -9999)
         self.assertEqual(image_info.year_diff, -9999)
@@ -118,9 +118,9 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertTrue(math.isnan(image_info.median[1]))
              
     def test_image_info_wv02_ndvi_int16(self):
-        srcdir = os.path.join(os.path.join(test_dir,'mosaic','pansh_ndvi'))
+        srcdir = os.path.join(os.path.join(test_dir, 'mosaic', 'pansh_ndvi'))
         image = 'WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u16rf3413_pansh_ndvi.tif'
-        image_info = mosaic.ImageInfo(os.path.join(srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(srcdir, image), 'IMAGE')
         
         self.assertEqual(image_info.xres, 16.0)
         self.assertEqual(image_info.yres, 16.0)
@@ -137,7 +137,7 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertEqual(image_info.ona, 19.4)
         self.assertEqual(image_info.cloudcover, 0.0)
         self.assertEqual(image_info.tdi, 24.0)
-        self.assertEqual(image_info.panfactor ,1)
+        self.assertEqual(image_info.panfactor, 1)
         #self.assertEqual(image_info.exposure_factor, 0)
         self.assertEqual(image_info.date_diff, -9999)
         self.assertEqual(image_info.year_diff, -9999)
@@ -152,7 +152,7 @@ class TestMosaicImageInfo(unittest.TestCase):
     
     def test_image_info_multispectral_dg_ge01(self):
         image = 'GE01_20130728161916_1050410002608900_13JUL28161916-M1BS-054448357040_01_P002_u08mr3413.tif'
-        image_info = mosaic.ImageInfo(os.path.join(self.srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(self.srcdir, image), 'IMAGE')
         self.maxDiff = None
         
         self.assertEqual(image_info.xres, 32.0)
@@ -170,7 +170,7 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertEqual(image_info.ona, 25.0)
         self.assertEqual(image_info.cloudcover, 0.0)
         self.assertEqual(image_info.tdi, 6.0)
-        self.assertEqual(image_info.panfactor ,1)
+        self.assertEqual(image_info.panfactor, 1)
         #self.assertEqual(image_info.exposure_factor, 0)
         self.assertEqual(image_info.date_diff, -9999)
         self.assertEqual(image_info.year_diff, -9999)
@@ -191,7 +191,7 @@ class TestMosaicImageInfo(unittest.TestCase):
     
     def test_image_info_wv01_with_tday_and_exposure(self):
         image = 'WV01_20080807153945_1020010003A5AC00_08AUG07153945-P1BS-052060421010_01_P011_u08mr3413.tif'
-        image_info = mosaic.ImageInfo(os.path.join(self.srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(self.srcdir, image), 'IMAGE')
         
         self.assertEqual(image_info.xres, 16.0)
         self.assertEqual(image_info.yres, 16.0)
@@ -221,7 +221,7 @@ class TestMosaicImageInfo(unittest.TestCase):
 
     def test_image_info_wv01_with_tyear(self):
         image = 'WV01_20080807153945_1020010003A5AC00_08AUG07153945-P1BS-052060421010_01_P011_u08mr3413.tif'
-        image_info = mosaic.ImageInfo(os.path.join(self.srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(self.srcdir, image), 'IMAGE')
 
         self.assertEqual(image_info.xres, 16.0)
         self.assertEqual(image_info.yres, 16.0)
@@ -247,7 +247,7 @@ class TestMosaicImageInfo(unittest.TestCase):
 
     def test_image_info_wv02_with_cc_max(self):
         image = 'WV02_20110504155551_103001000BA45E00_11MAY04155551-P1BS-500085264180_01_P002_u08mr3413.tif'
-        image_info = mosaic.ImageInfo(os.path.join(self.srcdir,image), 'IMAGE')
+        image_info = mosaic.ImageInfo(os.path.join(self.srcdir, image), 'IMAGE')
         
         self.assertEqual(image_info.xres, 16.0)
         self.assertEqual(image_info.yres, 16.0)
@@ -265,26 +265,29 @@ class TestMosaicImageInfo(unittest.TestCase):
         self.assertEqual(image_info.ona, 19.0)
         self.assertEqual(image_info.cloudcover, 0.29)
         self.assertEqual(image_info.tdi, 48.0)
-        self.assertEqual(image_info.panfactor ,1)
+        self.assertEqual(image_info.panfactor, 1)
         #self.assertEqual(image_info.exposure_factor, 0)
         self.assertEqual(image_info.date_diff, -9999)
         self.assertEqual(image_info.year_diff, -9999)
         self.assertAlmostEqual(image_info.score, -1)
         
         image_info.get_raster_stats()
-        stat_dct =  {1: [80.0, 191.0, 185.7102777536714, 6.965814755751974]}
-        datapixelcount_dct =  {1: 1152100}
+        stat_dct = {1: [80.0, 191.0, 185.7102777536714, 6.965814755751974]}
+        datapixelcount_dct = {1: 1152100}
         for i in range(len(image_info.stat_dct[1])):
             self.assertAlmostEqual(image_info.stat_dct[1][i], stat_dct[1][i])
         self.assertEqual(image_info.datapixelcount_dct, datapixelcount_dct)
 
     def test_filter_images(self):
-        image_list = glob.glob(os.path.join(self.srcdir,'*.tif'))
-        imginfo_list = [mosaic.ImageInfo(image,"IMAGE") for image in image_list]
+        image_list = glob.glob(os.path.join(self.srcdir, '*.tif'))
+        imginfo_list = [mosaic.ImageInfo(image, "IMAGE") for image in image_list]
         filter_list = [iinfo.srcfn for iinfo in imginfo_list]
-        self.assertIn('WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u08rf3413.tif', filter_list)
-        self.assertIn('GE01_20130728161916_1050410002608900_13JUL28161916-P1BS-054448357040_01_P002_u16rf3413.tif', filter_list)
-        self.assertIn('WV02_20131123162834_10300100293C3400_13NOV23162834-P1BS-500408660030_01_P005_u08mr3413.tif', filter_list)
+        self.assertIn('WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u08rf3413.tif',
+                      filter_list)
+        self.assertIn('GE01_20130728161916_1050410002608900_13JUL28161916-P1BS-054448357040_01_P002_u16rf3413.tif',
+                      filter_list)
+        self.assertIn('WV02_20131123162834_10300100293C3400_13NOV23162834-P1BS-500408660030_01_P005_u08mr3413.tif',
+                      filter_list)
 
         mosaic_args = MosaicArgs()
         mosaic_args.extent = [-820000.0, -800000.0, -2420000.0, -2400000.0]
@@ -295,13 +298,16 @@ class TestMosaicImageInfo(unittest.TestCase):
         filter_list = [iinfo.srcfn for iinfo in imginfo_list2]
         
         self.assertEqual(len(imginfo_list2), 8)
-        self.assertNotIn('WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u08rf3413.tif', filter_list)
-        self.assertNotIn('GE01_20130728161916_1050410002608900_13JUL28161916-P1BS-054448357040_01_P002_u16rf3413.tif', filter_list)
+        self.assertNotIn('WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u08rf3413.tif',
+                         filter_list)
+        self.assertNotIn('GE01_20130728161916_1050410002608900_13JUL28161916-P1BS-054448357040_01_P002_u16rf3413.tif',
+                         filter_list)
         
         imginfo_list3 = mosaic.filter_images_by_geometry(imginfo_list2, mosaic_params)
         filter_list = [iinfo.srcfn for iinfo in imginfo_list3]
         self.assertEqual(len(imginfo_list3), 7)
-        self.assertNotIn('WV02_20131123162834_10300100293C3400_13NOV23162834-P1BS-500408660030_01_P005_u08mr3413.tif', filter_list)
+        self.assertNotIn('WV02_20131123162834_10300100293C3400_13NOV23162834-P1BS-500408660030_01_P005_u08mr3413.tif',
+                         filter_list)
 
  
 class MosaicArgs(object):
@@ -335,10 +341,10 @@ if __name__ == '__main__':
     if args.testdata:
         test_dir = os.path.abspath(args.testdata)
     else:
-        test_dir = os.path.join(script_dir,'testdata')
+        test_dir = os.path.join(script_dir, 'testdata')
     
     if not os.path.isdir(test_dir):
-        parser.error("Test data folder does not exist: %s" %test_dir)
+        parser.error("Test data folder does not exist: {}".format(test_dir))
         
     test_cases = [
         TestMosaicImageInfo

--- a/tests/unit_test_ortho_functions.py
+++ b/tests/unit_test_ortho_functions.py
@@ -1,5 +1,6 @@
 import unittest, os, sys, glob, shutil, argparse, logging
 import gdal, ogr, osr, gdalconst
+import xml
 
 script_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
 root_dir = os.path.dirname(script_dir)

--- a/tests/unit_test_ortho_functions.py
+++ b/tests/unit_test_ortho_functions.py
@@ -53,7 +53,7 @@ class TestMetadata(unittest.TestCase):
             metapath = os.path.join(self.srcdir,mdf)
             try:
                 calib_dict = ortho_functions.getDGXmlData(metapath,self.stretch)
-            except xml.parsers.expat.ExpatError, e:
+            except xml.parsers.expat.ExpatError as e:
                 calib_dict = False
             
             self.assertEqual(bool(calib_dict),result)

--- a/tests/unit_test_ortho_functions.py
+++ b/tests/unit_test_ortho_functions.py
@@ -70,7 +70,7 @@ class TestMetadata(unittest.TestCase):
                     self.assertGreater(calib_dict['BAND_P'][1], -0.029)
                     self.assertLess(calib_dict['BAND_P'][1], -0.0098)
                 if 'BAND_B' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_B'][1], -0.1306)
+                    self.assertGreater(calib_dict['BAND_B'][1], -0.1307)
                     self.assertLess(calib_dict['BAND_B'][1], -0.0085)
                 if 'BAND_B' in calib_dict and 'BAND_G' in calib_dict: ### check bands are not equal
                     self.assertNotEqual(calib_dict['BAND_B'][0], calib_dict['BAND_G'][0])

--- a/tests/unit_test_ortho_functions.py
+++ b/tests/unit_test_ortho_functions.py
@@ -11,182 +11,183 @@ from lib import ortho_functions, utils
 #logger = logging.getLogger("logger")
 # lso = logging.StreamHandler()
 # lso.setLevel(logging.ERROR)
-# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
 # lso.setFormatter(formatter)
 # logger.addHandler(lso)
+
 
 class TestMetadata(unittest.TestCase):
     
     def setUp(self):
         self.stretch = 'rf'
         self.rd_stretch = 'rd'
-        self.srcdir = os.path.join(test_dir,'metadata_files')
+        self.srcdir = os.path.join(test_dir, 'metadata_files')
     
     #@unittest.skip("skipping")
     def test_parse_DG_md_files(self):
         
         dg_files = (
             ##(file name, if passes)
-            ('10APR23190859-M2AS-052462689010_01_P001.XML',True), ## 2A unrenamed
-            ('12JUL19233558-M1BS-052754253040_01_P001.XML',True), ## 1B unrenamed
-            ('12AUG27132242-M1BS-500122876080_01_P006.XML',False), ## 1B unrenamed truncated xml
-            ('GE01_11OCT122053047-P1BS-10504100009FD100.xml',True), #### GE01 image wth abscalfact in W/m2/um
-            ('GE01_14APR022119147-M1BS-1050410010473600.xml',True), #### GE01 image wth abscalfact in W/cm2/nm
-            ('GE01_20140402211914_1050410010473600_14APR02211914-M1BS-053720734020_01_P003.XML',True), ##GE01 pgctools3 name
-            ('QB02_02OCT092117107-M2AS_R1C1-101001000153C800.xml',True), #2A tiled pgctools2 renamed
-            ('QB02_12AUG271322429-M1BS-10100100101AD000.xml',True),  #1B pgctools2 renamed
-            ('QB02_20021009211710_101001000153C800_02OCT09211710-M2AS_R1C1-052075481010_01_P001.xml',True),
-            ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.XML',True),
-            ('WV01_09OCT042222158-P1BS-1020010009B33500.xml',True),
-            ('WV01_12MAR262229422-P1BS-102001001B02FA00.xml',True),
-            ('WV01_20091004222215_1020010009B33500_09OCT04222215-P1BS-052532098020_01_P019.xml',True),
-            ('WV01_20120326222942_102001001B02FA00_12MAR26222942-P1BS-052596100010_03_P007.XML',True),
-            ('WV02_10APR231908590-M2AS_R1C1-1030010005C7AF00.xml',True),
-            ('WV02_10APR231908590-M2AS_R2C3-1030010005C7AF00.xml',True),
-            ('WV02_12JUL192335585-M1BS-103001001B998D00.xml',True),
-            ('WV02_13OCT050528024-P1BS-10300100278D8500.xml',True),
-            ('WV02_20131005052802_10300100278D8500_13OCT05052802-P1BS-500099283010_01_P004.XML',True),
-            ('WV03_14SEP192129471-M1BS-104001000227BF00.xml',True),
-            ('WV03_20140919212947_104001000227BF00_14SEP19212947-M1BS-500191821040_01_P002.XML',True),
+            ('10APR23190859-M2AS-052462689010_01_P001.XML', True), ## 2A unrenamed
+            ('12JUL19233558-M1BS-052754253040_01_P001.XML', True), ## 1B unrenamed
+            ('12AUG27132242-M1BS-500122876080_01_P006.XML', False), ## 1B unrenamed truncated xml
+            ('GE01_11OCT122053047-P1BS-10504100009FD100.xml', True), #### GE01 image wth abscalfact in W/m2/um
+            ('GE01_14APR022119147-M1BS-1050410010473600.xml', True), #### GE01 image wth abscalfact in W/cm2/nm
+            ('GE01_20140402211914_1050410010473600_14APR02211914-M1BS-053720734020_01_P003.XML', True), ##GE01 pgctools3 name
+            ('QB02_02OCT092117107-M2AS_R1C1-101001000153C800.xml', True), #2A tiled pgctools2 renamed
+            ('QB02_12AUG271322429-M1BS-10100100101AD000.xml', True),  #1B pgctools2 renamed
+            ('QB02_20021009211710_101001000153C800_02OCT09211710-M2AS_R1C1-052075481010_01_P001.xml', True),
+            ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.XML', True),
+            ('WV01_09OCT042222158-P1BS-1020010009B33500.xml', True),
+            ('WV01_12MAR262229422-P1BS-102001001B02FA00.xml', True),
+            ('WV01_20091004222215_1020010009B33500_09OCT04222215-P1BS-052532098020_01_P019.xml', True),
+            ('WV01_20120326222942_102001001B02FA00_12MAR26222942-P1BS-052596100010_03_P007.XML', True),
+            ('WV02_10APR231908590-M2AS_R1C1-1030010005C7AF00.xml', True),
+            ('WV02_10APR231908590-M2AS_R2C3-1030010005C7AF00.xml', True),
+            ('WV02_12JUL192335585-M1BS-103001001B998D00.xml', True),
+            ('WV02_13OCT050528024-P1BS-10300100278D8500.xml', True),
+            ('WV02_20131005052802_10300100278D8500_13OCT05052802-P1BS-500099283010_01_P004.XML', True),
+            ('WV03_14SEP192129471-M1BS-104001000227BF00.xml', True),
+            ('WV03_20140919212947_104001000227BF00_14SEP19212947-M1BS-500191821040_01_P002.XML', True),
         )
         
         for mdf, result in dg_files:  ### test reflectance
-            metapath = os.path.join(self.srcdir,mdf)
+            metapath = os.path.join(self.srcdir, mdf)
             try:
-                calib_dict = ortho_functions.getDGXmlData(metapath,self.stretch)
-            except xml.parsers.expat.ExpatError as e:
+                calib_dict = ortho_functions.getDGXmlData(metapath, self.stretch)
+            except xml.parsers.expat.ExpatError:
                 calib_dict = False
             
-            self.assertEqual(bool(calib_dict),result)
+            self.assertEqual(bool(calib_dict), result)
             if calib_dict:
                 if 'BAND_P' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_P'][0],0.0005)
-                    self.assertLess(calib_dict['BAND_P'][0],0.0015)
+                    self.assertGreater(calib_dict['BAND_P'][0], 0.0005)
+                    self.assertLess(calib_dict['BAND_P'][0], 0.0015)
                 if 'BAND_B' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_B'][0],0.00045)
-                    self.assertLess(calib_dict['BAND_B'][0],0.0012)
+                    self.assertGreater(calib_dict['BAND_B'][0], 0.00045)
+                    self.assertLess(calib_dict['BAND_B'][0], 0.0012)
                 if 'BAND_P' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_P'][1],-0.029)
-                    self.assertLess(calib_dict['BAND_P'][1],-0.0098)
+                    self.assertGreater(calib_dict['BAND_P'][1], -0.029)
+                    self.assertLess(calib_dict['BAND_P'][1], -0.0098)
                 if 'BAND_B' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_B'][1],-0.1306)
-                    self.assertLess(calib_dict['BAND_B'][1],-0.0085)
+                    self.assertGreater(calib_dict['BAND_B'][1], -0.1306)
+                    self.assertLess(calib_dict['BAND_B'][1], -0.0085)
                 if 'BAND_B' in calib_dict and 'BAND_G' in calib_dict: ### check bands are not equal
-                    self.assertNotEqual(calib_dict['BAND_B'][0],calib_dict['BAND_G'][0])
+                    self.assertNotEqual(calib_dict['BAND_B'][0], calib_dict['BAND_G'][0])
                     
         for mdf, result in dg_files:   ### test radiance
-            metapath = os.path.join(self.srcdir,mdf)
-            calib_dict = ortho_functions.getDGXmlData(metapath,self.rd_stretch)
-            self.assertEqual(bool(calib_dict),result)
+            metapath = os.path.join(self.srcdir, mdf)
+            calib_dict = ortho_functions.getDGXmlData(metapath, self.rd_stretch)
+            self.assertEqual(bool(calib_dict), result)
             if calib_dict:
                 #print calib_dict
                 if 'BAND_P' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_P'][0],0.08)
-                    self.assertLess(calib_dict['BAND_P'][0],0.15)
+                    self.assertGreater(calib_dict['BAND_P'][0], 0.08)
+                    self.assertLess(calib_dict['BAND_P'][0], 0.15)
                 if 'BAND_B' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_B'][0],0.17)
-                    self.assertLess(calib_dict['BAND_B'][0],0.33)
+                    self.assertGreater(calib_dict['BAND_B'][0], 0.17)
+                    self.assertLess(calib_dict['BAND_B'][0], 0.33)
                 if 'BAND_P' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_P'][1],-4.5)
-                    self.assertLess(calib_dict['BAND_P'][1],-1.4)
+                    self.assertGreater(calib_dict['BAND_P'][1], -4.5)
+                    self.assertLess(calib_dict['BAND_P'][1], -1.4)
                 if 'BAND_B' in calib_dict:
-                    self.assertGreater(calib_dict['BAND_B'][1],-9.7)
-                    self.assertLess(calib_dict['BAND_B'][1],-2.8)
+                    self.assertGreater(calib_dict['BAND_B'][1], -9.7)
+                    self.assertLess(calib_dict['BAND_B'][1], -2.8)
                 if 'BAND_B' in calib_dict and 'BAND_G' in calib_dict: ### check bands are not equal
-                    self.assertNotEqual(calib_dict['BAND_B'][0],calib_dict['BAND_G'][0])
+                    self.assertNotEqual(calib_dict['BAND_B'][0], calib_dict['BAND_G'][0])
                            
     #@unittest.skip("skipping")     
     def test_parse_GE_md_files(self):
         ge_files = (
-            ('GE01_110108M0010160234A222000100252M_000500940.txt',True),
+            ('GE01_110108M0010160234A222000100252M_000500940.txt', True),
         )
         
         for mdf, result in ge_files: ### test reflectance
-            metapath = os.path.join(self.srcdir,mdf)
-            calib_dict = ortho_functions.GetGEcalibDict(metapath,self.stretch)
-            self.assertEqual(bool(calib_dict),result)
+            metapath = os.path.join(self.srcdir, mdf)
+            calib_dict = ortho_functions.GetGEcalibDict(metapath, self.stretch)
+            self.assertEqual(bool(calib_dict), result)
             if calib_dict:
                 
                 if 5 in calib_dict:  # pan band 
-                    self.assertGreater(calib_dict[5][0],0.0002)
-                    self.assertLess(calib_dict[5][0],0.0008)
+                    self.assertGreater(calib_dict[5][0], 0.0002)
+                    self.assertLess(calib_dict[5][0], 0.0008)
                 if 1 in calib_dict:  # blue band
-                    self.assertGreater(calib_dict[1][0],0.0002)
-                    self.assertLess(calib_dict[1][0],0.0008)
+                    self.assertGreater(calib_dict[1][0], 0.0002)
+                    self.assertLess(calib_dict[1][0], 0.0008)
                 if 5 in calib_dict:  # pan band bias
-                    self.assertEqual(calib_dict[5][1],0)
+                    self.assertEqual(calib_dict[5][1], 0)
                 if 1 in calib_dict:  # blue band bias
-                    self.assertEqual(calib_dict[1][1],0)
+                    self.assertEqual(calib_dict[1][1], 0)
                 if 1 in calib_dict and 2 in calib_dict: ### check bands are not equal
-                    self.assertNotEqual(calib_dict[1][0],calib_dict[2][0])
+                    self.assertNotEqual(calib_dict[1][0], calib_dict[2][0])
                     
         for mdf, result in ge_files:  ### test radiance
-            metapath = os.path.join(self.srcdir,mdf)
-            calib_dict = ortho_functions.GetGEcalibDict(metapath,self.rd_stretch)
-            self.assertEqual(bool(calib_dict),result)
+            metapath = os.path.join(self.srcdir, mdf)
+            calib_dict = ortho_functions.GetGEcalibDict(metapath, self.rd_stretch)
+            self.assertEqual(bool(calib_dict), result)
             if calib_dict:
                 
                 if 5 in calib_dict:  # pan band
-                    self.assertGreater(calib_dict[5][0],0.01)
-                    self.assertLess(calib_dict[5][0],0.02)
+                    self.assertGreater(calib_dict[5][0], 0.01)
+                    self.assertLess(calib_dict[5][0], 0.02)
                 if 1 in calib_dict:  # blue band
-                    self.assertGreater(calib_dict[1][0],0.01)
-                    self.assertLess(calib_dict[1][0],0.02)
+                    self.assertGreater(calib_dict[1][0], 0.01)
+                    self.assertLess(calib_dict[1][0], 0.02)
                 if 5 in calib_dict:  # pan band bias
-                    self.assertEqual(calib_dict[5][1],0)
+                    self.assertEqual(calib_dict[5][1], 0)
                 if 1 in calib_dict:  # blue band bias
-                    self.assertEqual(calib_dict[1][1],0)
+                    self.assertEqual(calib_dict[1][1], 0)
                 if 1 in calib_dict and 2 in calib_dict: ### check bands are not equal
-                    self.assertNotEqual(calib_dict[1][0],calib_dict[2][0])
+                    self.assertNotEqual(calib_dict[1][0], calib_dict[2][0])
         
     def test_parse_IK_md_files(self):
         
         ik_files = (
-            ('IK01_20010602215300_2001060221531300000010031227_po_387877_metadata.txt',True), ## test IK metadata file with multiple source IDs
-            ('IK01_19991222080400_1999122208040550000011606084_po_82037_metadata.txt',True),  ## test pgctools3 name
-            ('IK01_20050319201700_2005031920171340000011627450_po_333838_metadata.txt',True), ## test pgctools3 name
-            ('IK01_1999122208040550000011606084_pan_1569N.txt',True), ## test pgctools2 name
-            ('IK01_2005031920171340000011627450_rgb_5817N.txt',True), ## test pgctools2 name
+            ('IK01_20010602215300_2001060221531300000010031227_po_387877_metadata.txt', True), ## test IK metadata file with multiple source IDs
+            ('IK01_19991222080400_1999122208040550000011606084_po_82037_metadata.txt', True),  ## test pgctools3 name
+            ('IK01_20050319201700_2005031920171340000011627450_po_333838_metadata.txt', True), ## test pgctools3 name
+            ('IK01_1999122208040550000011606084_pan_1569N.txt', True), ## test pgctools2 name
+            ('IK01_2005031920171340000011627450_rgb_5817N.txt', True), ## test pgctools2 name
         )
         
         for mdf, result in ik_files:  ### test reflectance
-            metapath = os.path.join(self.srcdir,mdf)
-            calib_dict = ortho_functions.GetIKcalibDict(metapath,self.stretch)
-            self.assertEqual(bool(calib_dict),result)
+            metapath = os.path.join(self.srcdir, mdf)
+            calib_dict = ortho_functions.GetIKcalibDict(metapath, self.stretch)
+            self.assertEqual(bool(calib_dict), result)
             if calib_dict:
-                #print mdf
-                #print calib_dict
+                #print(mdf)
+                #print(calib_dict)
                 if 4 in calib_dict:  # pan band
-                    self.assertGreater(calib_dict[4][0],0.0004)
-                    self.assertLess(calib_dict[4][0],0.0006)
+                    self.assertGreater(calib_dict[4][0], 0.0004)
+                    self.assertLess(calib_dict[4][0], 0.0006)
                 if 0 in calib_dict:  # blue band
-                    self.assertGreater(calib_dict[0][0],0.0003)
-                    self.assertLess(calib_dict[0][0],0.0006)
+                    self.assertGreater(calib_dict[0][0], 0.0003)
+                    self.assertLess(calib_dict[0][0], 0.0006)
                 if 4 in calib_dict:  # pan band bias
-                    self.assertEqual(calib_dict[4][1],0)
+                    self.assertEqual(calib_dict[4][1], 0)
                 if 0 in calib_dict:  # blue band bias
-                    self.assertEqual(calib_dict[0][1],0)
+                    self.assertEqual(calib_dict[0][1], 0)
                 if 0 in calib_dict and 1 in calib_dict: ### check bands are not equal
-                    self.assertNotEqual(calib_dict[0][0],calib_dict[1][0])
+                    self.assertNotEqual(calib_dict[0][0], calib_dict[1][0])
                     
         for mdf, result in ik_files:    ### test radiance
-            metapath = os.path.join(self.srcdir,mdf)
-            calib_dict = ortho_functions.GetIKcalibDict(metapath,self.rd_stretch)
-            self.assertEqual(bool(calib_dict),result)
+            metapath = os.path.join(self.srcdir, mdf)
+            calib_dict = ortho_functions.GetIKcalibDict(metapath, self.rd_stretch)
+            self.assertEqual(bool(calib_dict), result)
             if calib_dict:
                 
                 if 4 in calib_dict:  # pan band
-                    self.assertGreater(calib_dict[4][0],0.1)
-                    self.assertLess(calib_dict[4][0],0.16)
+                    self.assertGreater(calib_dict[4][0], 0.1)
+                    self.assertLess(calib_dict[4][0], 0.16)
                 if 0 in calib_dict:  # blue band
-                    self.assertGreater(calib_dict[0][0],0.15)
-                    self.assertLess(calib_dict[0][0],0.25)
+                    self.assertGreater(calib_dict[0][0], 0.15)
+                    self.assertLess(calib_dict[0][0], 0.25)
                 if 5 in calib_dict:  # pan band bias
-                    self.assertEqual(calib_dict[4][1],0)
+                    self.assertEqual(calib_dict[4][1], 0)
                 if 1 in calib_dict:  # blue band bias
-                    self.assertEqual(calib_dict[0][1],0)
+                    self.assertEqual(calib_dict[0][1], 0)
                 if 0 in calib_dict and 1 in calib_dict: ### check bands are not equal
-                    self.assertNotEqual(calib_dict[0][0],calib_dict[1])
+                    self.assertNotEqual(calib_dict[0][0], calib_dict[1])
 
                     
 class TestCollectFiles(unittest.TestCase):
@@ -200,13 +201,13 @@ class TestCollectFiles(unittest.TestCase):
         for root, dirs, files in os.walk(os.path.join(test_dir, 'ortho')):
             for f in files:
                 if f.lower().endswith(".ntf") or f.lower().endswith(".tif"):
-                    #print f
+                    #print(f)
                     #### Find metadata file
-                    srcfp = os.path.join(root,f)
+                    srcfp = os.path.join(root, f)
                     
                     metafile = ortho_functions.GetDGMetadataPath(srcfp)
                     if metafile is None:
-                        metafile = ortho_functions.ExtractDGMetadataFile(srcfp,root)
+                        metafile = ortho_functions.ExtractDGMetadataFile(srcfp, root)
                     if metafile is None:
                         metafile = ortho_functions.GetIKMetadataPath(srcfp)
                     if metafile is None:
@@ -220,21 +221,26 @@ class TestCollectFiles(unittest.TestCase):
 class TestDEMOverlap(unittest.TestCase):
     
     def setUp(self):
-        self.dem = os.path.join(os.path.join(test_dir,'dem','ramp_lowres.tif'))
+        self.dem = os.path.join(os.path.join(test_dir, 'dem', 'ramp_lowres.tif'))
         self.srs = utils.SpatialRef(4326)
     
     def test_dem_overlap(self):
-        
         image_geom_wkts = [
-            ('POLYGON ((-52.23 70.843333,-51.735 70.844444,-51.736667 70.760556,-52.23 70.759722,-52.23 70.843333))',False), # False
-            ('POLYGON ((-64.23 -70.843333,-63.735 -70.844444,-63.736667 -70.760556,-64.23 -70.759722,-64.23 -70.843333))',True), # True
-            ('POLYGON ((-52.23 -50.843333,-51.735 -50.844444,-51.736667 -50.760556,-52.23 -50.759722,-52.23 -50.843333))', False) # False
+            ('POLYGON ((-52.23 70.843333,-51.735 70.844444,-51.736667 70.760556,-52.23 70.759722,-52.23 70.843333))',
+             False),  # False
+            (
+            'POLYGON ((-64.23 -70.843333,-63.735 -70.844444,-63.736667 -70.760556,-64.23 -70.759722,-64.23 -70.843333))',
+            True),  # True
+            (
+            'POLYGON ((-52.23 -50.843333,-51.735 -50.844444,-51.736667 -50.760556,-52.23 -50.759722,-52.23 -50.843333))',
+            False)  # False
         ]
         
         for wkt, result in image_geom_wkts:
             test_result = ortho_functions.overlap_check(wkt, self.srs, self.dem)
             self.assertEqual(test_result, result)
-    
+
+
 class TestTargetExtent(unittest.TestCase):
         
     def test_target_extent(self):
@@ -243,7 +249,8 @@ class TestTargetExtent(unittest.TestCase):
         args = ProcessArgs()
         info = ImageInfo()
         rc = ortho_functions.GetImageStats(args, info, target_extent_geom)
-        self.assertEqual(info.extent, '-te 805772.000000000000 2487233.000000000000 811661.000000000000 2505832.000000000000 ')
+        self.assertEqual(info.extent,
+                         '-te 805772.000000000000 2487233.000000000000 811661.000000000000 2505832.000000000000 ')
    
         
 class ProcessArgs(object):
@@ -254,12 +261,12 @@ class ProcessArgs(object):
         self.bgrn = False
         self.stretch = 'rf'
         self.spatial_ref = utils.SpatialRef(self.epsg)
-        
+
+
 class ImageInfo(object):
     def __init__(self):
         self.srcfn = 'GE01_20110307105821_1050410001518E00_11MAR07105821-M1BS-500657359080_01_P008.ntf'
-        self.localsrc = os.path.join(os.path.join(test_dir,'ortho',self.srcfn))
-
+        self.localsrc = os.path.join(os.path.join(test_dir, 'ortho', self.srcfn))
 
 
 if __name__ == '__main__':
@@ -278,10 +285,10 @@ if __name__ == '__main__':
     if args.testdata:
         test_dir = os.path.abspath(args.testdata)
     else:
-        test_dir = os.path.join(script_dir,'testdata')
+        test_dir = os.path.join(script_dir, 'testdata')
     
     if not os.path.isdir(test_dir):
-        parser.error("Test data folder does not exist: %s" %test_dir)
+        parser.error("Test data folder does not exist: {}".format(test_dir))
         
     test_cases = [
         TestMetadata,

--- a/tests/unit_test_taskhandler.py
+++ b/tests/unit_test_taskhandler.py
@@ -10,9 +10,10 @@ from lib import taskhandler
 logger = logging.getLogger("logger")
 # lso = logging.StreamHandler()
 # lso.setLevel(logging.ERROR)
-# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
+# formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
 # lso.setFormatter(formatter)
 # logger.addHandler(lso)
+
 
 class TestConvertArgs(unittest.TestCase):
     


### PR DESCRIPTION
These changes ensure all scripts are compatible with both Python 2.7+ and 3. The core functionality is essentially the same, but several conventions (e.g., string parsing, data type handling) were modified to support both versions. Numerous formatting conventions were modified for consistency. Where possible, all non-cosmetic changes were submitted as distinct commits for maximum traceability. 

Code testing was performed using Python 2.7.13 (with GDAL 2.1.1) and Python 3.6.5 (with GDAL 2.2.4) using [Pylint](https://www.pylint.org/), imagery_utils' built-in function/unit tests, and ad hoc tests. 

Regression testing was performed, and passed without error, using the GeoTIFF files produced by func_test_ortho.py, using the original code run in Python 2, the new code run in Python 2, and the new code run in Python 3. 