### PR TITLE
Mosaic scripts updates

### DIFF
--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -106,9 +106,14 @@ class ImageInfo:
         self.yres = None
         self.datatype = None
 
+        self.status = None
         self.sataz = None
         self.satel = None
         self.sunaz = None
+
+        i = feat.GetFieldIndex("STATUS")
+        if i != -1:
+            self.status = feat.GetFieldAsString(i)
         
         i = feat.GetFieldIndex("SUN_ELEV")
         if i != -1:

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -58,6 +58,9 @@ def main():
     parser.add_argument("--median-remove", action="store_true", default=False,
                         help="subtract the median from each input image before forming the mosaic in order to correct "
                              "for contrast")
+    parser.add_argument("--allow-invalid-geom", action="store_true", default=False,
+                        help="normally, if 1 or more images has a invalid geometry, a tile will not be created. this "
+                             "option will attempt to create a mosaic with the remaining valid geometries, if any.")
     parser.add_argument("--mode", choices=mosaic.MODES, default="ALL",
                         help=" mode: ALL- all steps (default), SHP- create shapefiles, MOSAIC- create tiled tifs, "
                              "TEST- create log only")
@@ -373,8 +376,12 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             logger.debug("Image has an invalid score: %s --> %i", iinfo.srcfp, iinfo.score)
 
     if not all_valid:
-        raise RuntimeError("Some source images do not have valid geometries.  Cannot proceeed")
- 
+        if not args.allow_invalid_geom:
+            raise RuntimeError("Some source images do not have valid geometries.  Cannot proceeed")
+        else:
+            logger.info("--allow-invalid-geom used; mosaic will be created using %i valid images (%i invalid \
+                        images not used.)".format(len(imginfo_list4), len(imginfo_list3)-len(imginfo_list4)))
+
     # Get stats if needed
     logger.info("Getting image metadata")
     for iinfo in imginfo_list4:

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -417,9 +417,8 @@ def HandleTile(t, src, dstdir, csvpath, args, exclude_list):
                     otxtpath_ontape = os.path.join(dstdir, "{}_{}_orig_ontape.csv".format(args.mosaic, t.name))
                     mtxtpath = os.path.join(dstdir, "{}_{}_ortho.txt".format(args.mosaic, t.name))
 
-                    raw_fromtape_path = os.path.join(dstdir, "raw_fromtape")
-                    if not os.path.isdir(raw_fromtape_path):
-                        os.mkdir(raw_fromtape_path)
+                    rn_fromtape_basedir = os.path.join(dstdir, "renamed_fromtape")
+                    rn_fromtape_path = os.path.join(rn_fromtape_basedir, t.name)
 
                     otxt = open(otxtpath, 'w')
                     ttxt = open(otxtpath_ontape, 'w')
@@ -440,11 +439,10 @@ def HandleTile(t, src, dstdir, csvpath, args, exclude_list):
                             ttxt.write("{0},{1},{2}\n".format(iinfo.scene_id, iinfo.srcfp, iinfo.status))
                             # get srcfp with file extension
                             srcfp_file = os.path.basename(iinfo.srcfp)
-                            otxt.write("{}\n".format(os.path.join(raw_fromtape_path, srcfp_file)))
+                            otxt.write("{}\n".format(os.path.join(rn_fromtape_path, srcfp_file)))
 
                         else:
                             otxt.write("{}\n".format(iinfo.srcfp))
-
 
                         m_fn = "{0}_u08{1}{2}.tif".format(
                             os.path.splitext(iinfo.srcfn)[0],
@@ -459,8 +457,14 @@ def HandleTile(t, src, dstdir, csvpath, args, exclude_list):
                     if tape_ct == 0:
                         logger.debug("No files need to be pulled from tape.")
                         os.remove(otxtpath_ontape)
-                        os.rmdir(raw_fromtape_path)  # os.rmdir() only removes empty directories
+
                     else:
+                        # make output dirs from tape
+                        if not os.path.isdir(rn_fromtape_basedir):
+                            os.mkdir(rn_fromtape_basedir)
+                        if not os.path.isdir(rn_fromtape_path):
+                            os.mkdir(rn_fromtape_path)
+
                         tape_tmp = os.path.join(dstdir, "{0}_{1}_tmp".format(args.mosaic, t.name))
                         if not os.path.isdir(tape_tmp):
                             os.mkdir(tape_tmp)
@@ -470,7 +474,7 @@ def HandleTile(t, src, dstdir, csvpath, args, exclude_list):
                                        "orthorectification). Please set a --tmp path (use '{4}').\n"
                                        "Note that if some (or all) scenes have already been pulled from tape, ir.py "
                                        "will not pull them again.\n".
-                                       format(tape_ct, otxtpath_ontape, raw_fromtape_path, otxtpath, tape_tmp))
+                                       format(tape_ct, otxtpath_ontape, rn_fromtape_path, otxtpath, tape_tmp))
 
                         tape_log = "{0}_{1}_ir_log_{2}.log".format(args.mosaic, t.name,
                                                                    datetime.today().strftime("%Y%m%d%H%M%S"))
@@ -479,7 +483,7 @@ def HandleTile(t, src, dstdir, csvpath, args, exclude_list):
                         logger.info("Suggested ir.py command:\n\n"
                                     ""
                                     "python {}ir.py -i {} -o {} --tmp {} -tm link 2>&1 | tee {}"
-                        .format(root_pgclib_path, otxtpath_ontape, raw_fromtape_path, tape_tmp,
+                        .format(root_pgclib_path, otxtpath_ontape, rn_fromtape_path, tape_tmp,
                                 os.path.join(dstdir, tape_log)))
 
 

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -482,8 +482,6 @@ def HandleTile(t, src, dstdir, csvpath, args, exclude_list):
                         .format(root_pgclib_path, otxtpath_ontape, raw_fromtape_path, tape_tmp,
                                 os.path.join(dstdir, tape_log)))
 
-                        ## TODO: test ir.py, and then make sure the mosaics can still be built!
-
 
 if __name__ == '__main__':
     main()

--- a/qsub_mosaic.sh
+++ b/qsub_mosaic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l nodes=1:ppn=32
+#PBS -l nodes=1:ppn=32,mem=126gb
 #PBS -l walltime=48:00:00
 #PBS -m n
 #PBS -k oe

--- a/qsub_ndvi.sh
+++ b/qsub_ndvi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l walltime=24:00:00,nodes=1:ppn=2
+#PBS -l walltime=24:00:00,nodes=1:ppn=2,mem=8gb
 #PBS -m n
 #PBS -k oe
 #PBS -j oe

--- a/qsub_ortho.sh
+++ b/qsub_ortho.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l walltime=20:00:00,nodes=1:ppn=2
+#PBS -l walltime=20:00:00,nodes=1:ppn=2,mem=8gb
 #PBS -m n
 #PBS -k oe
 #PBS -j oe

--- a/qsub_pansharpen.sh
+++ b/qsub_pansharpen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l walltime=24:00:00,nodes=1:ppn=2
+#PBS -l walltime=24:00:00,nodes=1:ppn=2,mem=8gb
 #PBS -m n
 #PBS -k oe
 #PBS -j oe


### PR DESCRIPTION
3 changes:

1. A new pgc_mosaic.py flag, --allow-invalid-geom, to allow tiles to be built if one or more input images is invalid.
2. pgc_mosaic_query_index.py will now create a list of scene IDs that need to be pulled from tape, and gives a suggested ir.py call to use. Any tape scene is represented in the *_orig.txt files with a hard-coded path to a parent directory named "renamed_fromtape". A .csv of scenes needed from tape is generated (and confirmed to work with ir.py). 
3. The PBS submission scripts now have a specific memory requirement. This was determined by the amount of memory on the old PGC nodes, divided by the nproc of the old PGC nodes, and rounded up. This is multiplied by the number of nodes (ppn) requested.   