### PR TITLE
GDAL 3 axis preservation

### DIFF
--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -1002,9 +1002,9 @@ def filterMatchingImages(imginfo_list, params):
     for iinfo in imginfo_list:
         #print(iinfo.srcfp, iinfo.proj)
         isSame = True
-        p = osr.SpatialReference()
+        p = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
         p.ImportFromWkt(iinfo.proj)
-        rp = osr.SpatialReference()
+        rp = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
         rp.ImportFromWkt(params.proj)
         if p.IsSame(rp) is False:
             isSame = False

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -497,7 +497,7 @@ def stackIkBands(dstfp, members):
             proj = src_ds.GetGCPProjection()
         else:
             proj = src_ds.GetProjectionRef()
-        s_srs = osr.SpatialReference(proj)
+        s_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference(proj))
         s_srs_proj4 = s_srs.ExportToProj4()
 
         #### Remove keys we want to leave or set ourselves
@@ -837,9 +837,9 @@ def GetImageStats(args, info, target_extent_geom=None):
         extent_geom = ogr.CreateGeometryFromWkt(poly_wkt)
 
         #### Create srs objects
-        s_srs = osr.SpatialReference(proj)
+        s_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference(proj))
         t_srs = args.spatial_ref.srs
-        g_srs = osr.SpatialReference()
+        g_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
         g_srs.ImportFromEPSG(WGS84)
         sg_ct = osr.CoordinateTransformation(s_srs, g_srs)
         gt_ct = osr.CoordinateTransformation(g_srs, t_srs)
@@ -1415,7 +1415,8 @@ def overlap_check(geometry_wkt, spatial_ref, demPath):
                                                                                         maxy, maxx, miny, minx, miny)
             demGeometry = ogr.CreateGeometryFromWkt(dem_geometry_wkt)
             logger.info("DEM extent: %s", str(demGeometry))
-            demSpatialReference = osr.SpatialReference(demProjection)
+            demSpatialReference = utils.osr_srs_preserve_axis_order(utils.osr_srs_preserve_axis_order(
+                osr.SpatialReference(demProjection)))
 
             coordinateTransformer = osr.CoordinateTransformation(imageSpatialReference, demSpatialReference)
             if not imageSpatialReference.IsSame(demSpatialReference):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -17,7 +17,8 @@ package_version = '1.5.4'
 class SpatialRef(object):
 
     def __init__(self, epsg):
-        srs = osr.SpatialReference()
+        srs = osr_srs_preserve_axis_order(osr.SpatialReference())
+
         try:
             epsgcode = int(epsg)
         except ValueError:
@@ -41,6 +42,15 @@ class SpatialRef(object):
         self.srs = srs
         self.proj4 = proj4_string
         self.epsg = epsgcode
+
+
+def osr_srs_preserve_axis_order(osr_srs):
+    try:
+        # revert to GDAL 2.x axis conventions to maintain consistent results if GDAL 3+ used
+        osr_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    except AttributeError:
+        pass
+    return osr_srs
 
 
 def get_bit_depth(outtype):

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -622,7 +622,7 @@ def build_shp(contribs, shp, args, params):
     shpd, shpn = os.path.split(shp)
     shpbn, shpe = os.path.splitext(shpn)
     
-    rp = osr.SpatialReference()
+    rp = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
     rp.ImportFromWkt(params.proj)
     
     lyr = vds.CreateLayer(shpbn, rp, ogr.wkbPolygon)
@@ -731,7 +731,7 @@ def build_tiles_shp(mosaicname, tiles, params):
         shpd, shpn = os.path.split(tiles_shp)
         shpbn, shpe = os.path.splitext(shpn)
         
-        rp = osr.SpatialReference()
+        rp = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
         rp.ImportFromWkt(params.proj)
         
         lyr = vds.CreateLayer(shpbn, rp, ogr.wkbPolygon)

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -215,7 +215,7 @@ def HandleTile(t, src, dstdir, csvpath, args, exclude_list):
     else:
         logger.info("Tile %s", t.name)
     
-        t_srs = osr.SpatialReference()
+        t_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
         t_srs.ImportFromEPSG(t.epsg)
         
         #### Open mfp

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -170,7 +170,7 @@ class ImagePair(object):
             extent_geom.AddGeometry(ring)
     
             #### Create srs objects
-            s_srs = osr.SpatialReference(proj)
+            s_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference(proj))
             t_srs = spatial_ref.srs
             st_ct = osr.CoordinateTransformation(s_srs, t_srs)
     

--- a/tests/unit_test_utils.py
+++ b/tests/unit_test_utils.py
@@ -82,8 +82,8 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             utils.SpatialRef(self.epsg_bad_2)  # break for invalid EPSG code
 
-        self.assertTrue(isinstance(sref_np.srs, utils.osr_srs_preserve_axis_order(osgeo.osr.SpatialReference)))
-        self.assertTrue(isinstance(sref_sp.srs, utils.osr_srs_preserve_axis_order(osgeo.osr.SpatialReference)))
+        self.assertTrue(isinstance(sref_np.srs, osgeo.osr.SpatialReference))
+        self.assertTrue(isinstance(sref_sp.srs, osgeo.osr.SpatialReference))
 
         self.assertTrue(sref_np.proj4, '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ')
         self.assertTrue(sref_sp.proj4, '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ')

--- a/tests/unit_test_utils.py
+++ b/tests/unit_test_utils.py
@@ -82,8 +82,8 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             utils.SpatialRef(self.epsg_bad_2)  # break for invalid EPSG code
 
-        self.assertTrue(isinstance(sref_np.srs, osgeo.osr.SpatialReference))
-        self.assertTrue(isinstance(sref_sp.srs, osgeo.osr.SpatialReference))
+        self.assertTrue(isinstance(sref_np.srs, utils.osr_srs_preserve_axis_order(osgeo.osr.SpatialReference)))
+        self.assertTrue(isinstance(sref_sp.srs, utils.osr_srs_preserve_axis_order(osgeo.osr.SpatialReference)))
 
         self.assertTrue(sref_np.proj4, '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ')
         self.assertTrue(sref_sp.proj4, '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ')


### PR DESCRIPTION
Function implemented in lib/utils.py to handle "traditional GIS" long/lat axis conventions. This will allow imagery_utils to provide consistent results when run with GDAL 3 or GDAL < 3. This is only an issue when osr.SpatialReference() is called, and the new wrapper function provided here will only alter it if necessary. 

Official documentation on the change: https://gdal.org/tutorials/osr_api_tut.html#crs-and-axis-order