### PR TITLE
Threading for gdalwarp and gdal_pansharpen

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Files starting with "qsub" and "slurm" are PBS and SLURM submission scripts.  Se
 
 ORTHO
 
-The orthorectification script can correct for terrain displacement and radiometric settings as well as alter the bit depth of the imagery.  Using the --pbs or --slurm options will sumit the jobs to an Torque job scheduler.  Alternatively, using the --parallel-processes option  will instruct the script to run multiple tasks in parallel.
+The orthorectification script can correct for terrain displacement and radiometric settings as well as alter the bit depth of the imagery.  Using the --pbs or --slurm options will submit the jobs to an Torque job scheduler.  Alternatively, using the --parallel-processes option will instruct the script to run multiple tasks in parallel.  Using --threads N will enable threading for gdalwarp, where N is the number of threads (or ALL_CPUS); this option will not work with --pbs/--slurm, and (threads * parallel processes) cannot exceed number of threads available on system.
 
 Example:  python pgc_ortho.py --epsg 3031 --dem DEM.tif --format GTiff --stretch ns --outtype UInt16 input_dir output dir
 
@@ -40,7 +40,7 @@ This example will evaluate all the 1-band images in input_dir and sort them acco
 
 PANSHARPEN
 
-The pansharpening utility applies the orthorectification process to both the pan and multi image in a pair and then pansharpens them using the GDAL tool gdal_pansharpen.  GDAL 2.1 is required for this tool to function.
+The pansharpening utility applies the orthorectification process to both the pan and multi image in a pair and then pansharpens them using the GDAL tool gdal_pansharpen.  GDAL 2.1 is required for this tool to function.  The --thread flag will apply threading to both gdalwarp and gdal_pansharpen operations.
 
 NDVI
 

--- a/README
+++ b/README
@@ -40,7 +40,7 @@ This example will evaluate all the 1-band images in input_dir and sort them acco
 
 PANSHARPEN
 
-The pansharpening utility applies the orthorectification process to both the pan and multi image in a pair and then pansharpens them using the GDAL tool gdal_pansharpen.  GDAL 2.1 is required for this tool to function.  The --thread flag will apply threading to both gdalwarp and gdal_pansharpen operations.
+The pansharpening utility applies the orthorectification process to both the pan and multi image in a pair and then pansharpens them using the GDAL tool gdal_pansharpen.  GDAL 2.1 is required for this tool to function.  The --threads flag will apply threading to both gdalwarp and gdal_pansharpen operations.
 
 NDVI
 

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -233,16 +233,19 @@ class ImageInfo:
 
 
 def thread_type():
-    def posintorall(input_value):
-        if type(input_value) == int:
+    def posintorall(arg_input):
+        try:
+            input_value = int(arg_input)
+        except ValueError:
+            if arg_input == "ALL_CPUS":
+                return arg_input
+            else:
+                raise argparse.ArgumentTypeError("Must be a positive integer or ALL_CPUS")
+        else:
             if input_value < 1:
                 raise argparse.ArgumentTypeError("Must be a positive integer or ALL_CPUS")
             else:
                 return input_value
-        elif input_value == "ALL_CPUS":
-            return input_value
-        else:
-            raise argparse.ArgumentTypeError("Must be a positive integer or ALL_CPUS")
     return posintorall
 
 

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -19,6 +19,15 @@ stretches = ["ns", "rf", "mr", "rd"]
 resamples = ["near", "bilinear", "cubic", "cubicspline", "lanczos"]
 gtiff_compressions = ["jpeg95", "lzw"]
 exts = ['.ntf', '.tif']
+ARGDEF_THREADS = 1
+try:
+    # Python 3.x only
+    ARGDEF_CPUS_AVAIL = os.cpu_count()
+except AttributeError:
+    # Python 2.x only
+    import multiprocessing
+    ARGDEF_CPUS_AVAIL = multiprocessing.cpu_count()
+
 
 WGS84 = 4326
 
@@ -223,6 +232,20 @@ class ImageInfo:
     pass
 
 
+def thread_type():
+    def posintorall(input_value):
+        if type(input_value) == int:
+            if input_value < 1:
+                raise argparse.ArgumentTypeError("Must be a positive integer or ALL_CPUS")
+            else:
+                return input_value
+        elif input_value == "ALL_CPUS":
+            return input_value
+        else:
+            raise argparse.ArgumentTypeError("Must be a positive integer or ALL_CPUS")
+    return posintorall
+
+
 def buildParentArgumentParser():
 
     #### Set Up Arguments
@@ -271,6 +294,14 @@ def buildParentArgumentParser():
     parser.add_argument("--ortho-height", type=int,
                         help='constant elevation to use for orthorectification (value should be in meters above '
                         'the wgs84 ellipoid)')
+    parser.add_argument("--threads", type=thread_type(),
+                        help='Number of threads to use for gdalwarp and gdal_pansharpen processes, if applicable '
+                             '(default={0}, number on system={1}). Can use any positive integer, or ALL_CPUS. '
+                             'Any value above system count will default to ALL_CPUS. If used with '
+                             '--parallel-processes, the (threads * number of processes) must be <= system count. '
+                             '--pbs/--slurm will only accept 1 thread.'
+                        .format(ARGDEF_THREADS, ARGDEF_CPUS_AVAIL),
+                        default=ARGDEF_THREADS)
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(utils.package_version))
 
     return parser, pos_arg_keys
@@ -279,6 +310,9 @@ def buildParentArgumentParser():
 def process_image(srcfp, dstfp, args, target_extent_geom=None):
 
     err = 0
+
+    #### Handle threads (default to 1 if arg not supplied)
+    gdal_thread_count = 1 if not hasattr(args, 'threads') else args.threads
 
     #### Instantiate ImageInfo object
     info = ImageInfo()
@@ -412,7 +446,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
     if not os.path.isfile(info.dstfp):
         #### Warp Image
         if not err == 1 and not os.path.isfile(info.warpfile):
-            rc = WarpImage(args, info)
+            rc = WarpImage(args, info, gdal_thread_count=gdal_thread_count)
             if rc == 1:
                 err = 1
                 logger.error("Error in image warping")
@@ -1207,15 +1241,22 @@ def prettify(elem):
     return reparsed.toprettyxml(indent="  ")
 
 
-def WarpImage(args, info):
+def WarpImage(args, info, gdal_thread_count=1):
 
     rc = 0
 
     pf = platform.platform()
     if pf.startswith("Linux"):
-        config_options = '-wm 2000 --config GDAL_CACHEMAX 2048 --config GDAL_NUM_THREADS 1'
+        config_options = '-wm 2000 --config GDAL_CACHEMAX 2048 --config GDAL_NUM_THREADS {0} -wo NUM_THREADS={0}'.\
+            format(gdal_thread_count)
     else:
-        config_options = '--config GDAL_NUM_THREADS 1'
+        config_options = '--config GDAL_NUM_THREADS {0} -wo NUM_THREADS={0}'.format(gdal_thread_count)
+    if type(gdal_thread_count) == str:
+        if gdal_thread_count == "ALL_CPUS":
+            config_options += ' -multi'
+    elif type(gdal_thread_count) == int:
+        if gdal_thread_count > 1:
+            config_options += ' -multi'
 
     if not os.path.isfile(info.warpfile):
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -11,7 +11,7 @@ gdal.SetConfigOption('GDAL_PAM_ENABLED', 'NO')
 logger = logging.getLogger("logger")
 logger.setLevel(logging.DEBUG)
 
-package_version = '1.5.6'
+package_version = '1.5.7'
 
 
 class SpatialRef(object):

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -71,16 +71,17 @@ def main():
             parser.error("qsub script path is not valid: {}".format(qsubpath))
 
     ## Verify processing options do not conflict
+    requested_threads = ortho_functions.ARGDEF_CPUS_AVAIL if args.threads == "ALL_CPUS" else args.threads
     if args.pbs and args.slurm:
         parser.error("Options --pbs and --slurm are mutually exclusive")
     if (args.pbs or args.slurm) and args.parallel_processes > 1:
         parser.error("HPC Options (--pbs or --slurm) and --parallel-processes > 1 are mutually exclusive")
-    if (args.pbs or args.slurm) and args.threads > 1:
+    if (args.pbs or args.slurm) and requested_threads > 1:
         parser.error("HPC Options (--pbs or --slurm) and --threads > 1 are mutually exclusive")
-    if args.threads < 1:
-        parser.error("--threads count must be positive, nonzero integer")
+    if requested_threads < 1:
+        parser.error("--threads count must be positive, nonzero integer or ALL_CPUS")
     if args.parallel_processes > 1:
-        total_proc_count = args.threads * args.parallel_processes
+        total_proc_count = requested_threads * args.parallel_processes
         if total_proc_count > ortho_functions.ARGDEF_CPUS_AVAIL:
             parser.error("the (threads * number of processes requested) ({0}) exceeds number of available threads "
                          "({1}); reduce --threads and/or --parallel-processes count"
@@ -116,9 +117,9 @@ def main():
     logger.addHandler(lso)
 
     #### Handle thread count that exceeds system limits
-    if args.threads > ortho_functions.ARGDEF_CPUS_AVAIL:
+    if requested_threads > ortho_functions.ARGDEF_CPUS_AVAIL:
         logger.info("threads requested ({0}) exceeds number available on system ({1}), setting thread count to "
-                    "'ALL_CPUS'".format(args.threads, ortho_functions.ARGDEF_CPUS_AVAIL))
+                    "'ALL_CPUS'".format(requested_threads, ortho_functions.ARGDEF_CPUS_AVAIL))
         args.threads = 'ALL_CPUS'
 
     #### Get args ready to pass to task handler

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -78,7 +78,7 @@ def main():
     if (args.pbs or args.slurm) and args.threads > 1:
         parser.error("HPC Options (--pbs or --slurm) and --threads > 1 are mutually exclusive")
     if args.threads < 1:
-        parser.error("--thread count must be positive, nonzero integer")
+        parser.error("--threads count must be positive, nonzero integer")
     if args.parallel_processes > 1:
         total_proc_count = args.threads * args.parallel_processes
         if total_proc_count > ortho_functions.ARGDEF_CPUS_AVAIL:

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -477,7 +477,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
                 format(py_ext, pan_threading, pan_local_dstfp, mul_local_dstfp, pansh_local_dstfp)
             taskhandler.exec_cmd(cmd)
     else:
-        print("Pan or Multi warped image does not exist\n\t{}\n\t{}").format(pan_local_dstfp, mul_local_dstfp)
+        logger.warning("Pan or Multi warped image does not exist\n\t{}\n\t{}".format(pan_local_dstfp, mul_local_dstfp))
 
     #### Make pyramids
     if os.path.isfile(pansh_local_dstfp):

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -245,6 +245,16 @@ def main():
         parser.error("Options --pbs and --slurm are mutually exclusive")
     if (args.pbs or args.slurm) and args.parallel_processes > 1:
         parser.error("HPC Options (--pbs or --slurm) and --parallel-processes > 1 are mutually exclusive")
+    if (args.pbs or args.slurm) and args.threads > 1:
+        parser.error("HPC Options (--pbs or --slurm) and --threads > 1 are mutually exclusive")
+    if args.threads < 1:
+        parser.error("--thread count must be positive, nonzero integer")
+    if args.parallel_processes > 1:
+        total_proc_count = args.threads * args.parallel_processes
+        if total_proc_count > ortho_functions.ARGDEF_CPUS_AVAIL:
+            parser.error("the (threads * number of processes requested) ({0}) exceeds number of available threads "
+                         "({1}); reduce --threads and/or --parallel-processes count"
+                         .format(total_proc_count, ortho_functions.ARGDEF_CPUS_AVAIL))
 
     #### Verify EPSG
     try:
@@ -266,6 +276,12 @@ def main():
     formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
     lso.setFormatter(formatter)
     logger.addHandler(lso)
+
+    #### Handle thread count that exceeds system limits
+    if args.threads > ortho_functions.ARGDEF_CPUS_AVAIL:
+        logger.info("threads requested ({0}) exceeds number available on system ({1}), setting thread count to "
+                    "'ALL_CPUS'".format(args.threads, ortho_functions.ARGDEF_CPUS_AVAIL))
+        args.threads = 'ALL_CPUS'
     
     #### Get args ready to pass to task handler
     arg_keys_to_remove = ('l', 'qsubscript', 'dryrun', 'pbs', 'slurm', 'parallel_processes')
@@ -448,12 +464,17 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
         py_ext = ''
     else:
         py_ext = '.py'
+
+    pan_threading = ''
+    if hasattr(args, 'threads'):
+        if args.threads != 1:
+            pan_threading = '-threads {}'.format(args.threads)
     
     logger.info("Pansharpening multispectral image")
     if os.path.isfile(pan_local_dstfp) and os.path.isfile(mul_local_dstfp):
         if not os.path.isfile(pansh_local_dstfp):
-            cmd = 'gdal_pansharpen{} -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co TILED=YES "{}" "{}" "{}"'.\
-                format(py_ext, pan_local_dstfp, mul_local_dstfp, pansh_local_dstfp)
+            cmd = 'gdal_pansharpen{} -co BIGTIFF=IF_SAFER -co COMPRESS=LZW -co TILED=YES {} "{}" "{}" "{}"'.\
+                format(py_ext, pan_threading, pan_local_dstfp, mul_local_dstfp, pansh_local_dstfp)
             taskhandler.exec_cmd(cmd)
     else:
         print("Pan or Multi warped image does not exist\n\t{}\n\t{}").format(pan_local_dstfp, mul_local_dstfp)

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -248,7 +248,7 @@ def main():
     if (args.pbs or args.slurm) and args.threads > 1:
         parser.error("HPC Options (--pbs or --slurm) and --threads > 1 are mutually exclusive")
     if args.threads < 1:
-        parser.error("--thread count must be positive, nonzero integer")
+        parser.error("--threads count must be positive, nonzero integer")
     if args.parallel_processes > 1:
         total_proc_count = args.threads * args.parallel_processes
         if total_proc_count > ortho_functions.ARGDEF_CPUS_AVAIL:


### PR DESCRIPTION
New `--threads` option that works with `pgc_ortho.py` and `pgc_pansharpen.py` to accelerate the gdalwarp and/or gdal_pansharpen.py processing. The flag accepts any nonzero integer or ALL_CPUS as arguments. Parser checks are in place to disable this in `--pbs`/`--slurm` processing, and will not let (threads * parallel processes) exceed the number of threads available on the system. Any standalone `--threads` argument exceeding the system thread count will default to the maximum available.

For `gdalwarp` this was implemented in the `--config` and warp options `-wo` flags. My testing found that threading of input dataset read `-oo` and output dataset write `-doo` had no effect. The requestor also tested these settings and found they improved performance. 

For `gdal_pansharpen.py` the `-threads` flag was added. When `--threads` is supplied to `pgc_pansharpen.py` threading will occur for both the `gdalwarp` and `gdal_pansharpen.py` processes.

The README has been updated with the new flag. A bugfix for a print string error is also included. 