### PR TITLE
Bugfix escaped quotes in command string for parallel processing

### DIFF
--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -6,6 +6,7 @@ task handler classes and methods
 
 import os, sys, shutil, signal, glob, re, logging, subprocess, platform
 import multiprocessing as mp
+import codecs
 
 #### Create Logger
 logger = logging.getLogger("logger")
@@ -122,6 +123,7 @@ class ParallelTaskHandler(object):
 
 def exec_cmd_mp(job):
     job_name, cmd = job
+    cmd = codecs.decode(cmd, 'unicode-escape')
     logger.info('Running job: %s', job_name)
     logger.debug('Cmd: %s', cmd)
     if platform.system() == "Windows":


### PR DESCRIPTION
Escaped quotes were added to all string arguments in earlier commit https://github.com/PolarGeospatialCenter/imagery_utils/commit/c0a8a1ae02147c42d57fc510350b55c9058a6310 to allow argument paths containing spaces