### PR TITLE
Change gdal version to 2.1.3 in qsub scripts to resolve numpy issue

### DIFF
--- a/qsub_mosaic.sh
+++ b/qsub_mosaic.sh
@@ -34,7 +34,7 @@ echo Working directory: $PBS_O_WORKDIR
 echo ________________________________________________________
 echo
 
-module load gdal/2.1.1
+module load gdal/2.1.3
 
 echo $p1
 time eval $p1

--- a/qsub_ortho.sh
+++ b/qsub_ortho.sh
@@ -35,7 +35,7 @@ echo
 
 cd $PBS_O_WORKDIR
 
-module load gdal/2.1.1
+module load gdal/2.1.3
 
 echo $p1
 time eval $p1

--- a/qsub_pansharpen.sh
+++ b/qsub_pansharpen.sh
@@ -35,7 +35,7 @@ echo
 
 cd $PBS_O_WORKDIR
 
-module load gdal/2.1.1
+module load gdal/2.1.3
 
 echo $p1
 time eval $p1


### PR DESCRIPTION
Testing the PR workflow with a quick fix to the GDAL version called in the qsub .sh scripts. The 2.1.1 version of the GDAL module did not have numpy installed, which caused the pgc_mosaic.py script to fail with the -pbs flag. Upon Erik's advice, I switched to 2.1.3, which resolved the issue. 