### PR TITLE
Show full stack trace in error messages/logs

### DIFF
--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -339,6 +339,7 @@ class ImageInfo:
                 try:
                     metad = utils.getGEMetadataAsXml(metapath)
                 except Exception as err:
+                    logger.error(utils.capture_error_trace())
                     logger.debug("ERROR parsing metadata: %s, %s", err, metapath)
                 #### Write IK01 code 
         
@@ -379,6 +380,7 @@ class ImageInfo:
                                 vallist.append(val)
                                 
                             except Exception as e:
+                                logger.error(utils.capture_error_trace())
                                 logger.debug("Error reading metadata values: %s, %s", metapath, e)
                                 
                     if dTags[tag] == 'tdi' and len(taglist) > 1:    

--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -1,9 +1,15 @@
-import os, sys, shutil, math, glob, re, tarfile, logging, platform, argparse, subprocess
-from datetime import datetime, timedelta
+
+import glob
+import logging
+import math
+import os
+import shutil
+from datetime import datetime
 from xml.etree import cElementTree as ET
-from osgeo import gdal, ogr, osr, gdalconst
+
 import numpy
 from numpy import flatnonzero
+from osgeo import gdal, ogr, osr
 
 from lib import utils
 

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -361,7 +361,8 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
     #### Verify EPSG
     try:
         spatial_ref = utils.SpatialRef(args.epsg)
-    except RuntimeError:
+    except RuntimeError as e:
+        logger.error(utils.capture_error_trace())
         logger.error("Invalid EPSG code: %i", args.epsg)
         err = 1
     else:
@@ -626,6 +627,7 @@ def stackIkBands(dstfp, members):
     try:
         os.remove(vrt)
     except Exception as e:
+        logger.error(utils.capture_error_trace())
         logger.warning("Cannot remove file: %s, %s", vrt, e)
     return rc
 
@@ -1065,6 +1067,7 @@ def ExtractDGMetadataFile(srcfp, wd):
                         fpfh.close()
                         tf.close()
             except Exception:
+                logger.error(utils.capture_error_trace())
                 logger.error("Cannot open Tar file: %s", tarpath)
 
     if metapath and os.path.isfile(metapath):
@@ -1516,6 +1519,7 @@ def ExtractRPB(item, rpb_p):
                     tf.close()
                     # status = 0
         except Exception:
+            logger.error(utils.capture_error_trace())
             logger.error("Cannot open Tar file: %s", tar_p)
             rc = 1
     else:
@@ -1559,6 +1563,7 @@ def getDGXmlData(xmlpath, stretch):
     try:
         xmldoc = minidom.parse(xmlpath)
     except Exception:
+        logger.error(utils.capture_error_trace())
         logger.error("Cannot parse metadata file: %s", xmlpath)
         return None
     else:
@@ -1824,6 +1829,7 @@ def getGEMetadata(fp_mode, metafile):
                 try:
                     band = int(node.attrib["bandNumber"])
                 except Exception:
+                    logger.error(utils.capture_error_trace())
                     logger.error("Unable to retrieve band number in GE metadata")
                 else:
                     node = node.find(".//{}".format(key))

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -1,11 +1,20 @@
-import os, sys, shutil, math, glob, re, tarfile, logging, platform, argparse
-from datetime import datetime, timedelta
 
-from lib import utils, taskhandler
+import argparse
+import glob
+import logging
+import math
+import os
+import platform
+import re
+import shutil
+import tarfile
+from datetime import datetime
 from xml.dom import minidom
 from xml.etree import cElementTree as ET
 
-from osgeo import gdal, ogr, osr, gdalconst
+from osgeo import gdal, gdalconst, ogr, osr
+
+from lib import taskhandler, utils
 
 #### Create Loggers
 logger = logging.getLogger("logger")

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -4,9 +4,13 @@
 task handler classes and methods
 """
 
-import os, sys, shutil, signal, glob, re, logging, subprocess, platform
-import multiprocessing as mp
 import codecs
+import logging
+import multiprocessing as mp
+import os
+import platform
+import signal
+import subprocess
 
 #### Create Logger
 logger = logging.getLogger("logger")

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -441,6 +441,10 @@ def doesCross180(geom):
     :param geom: <osgeo.ogr.Geometry>
     :return: <bool>
     """
+    if geom.GetGeometryName() == "MULTIPOLYGON":
+        err = "Function does not support testing MULTIPOLYGON geometry"
+        raise RuntimeError(err)
+
     result = False
     _mat = re.findall(r"-?\d+\.\d+", geom.ExportToWkt())
     if _mat:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,9 +1,13 @@
-import os, sys, shutil, math, glob, re, tarfile, logging, platform, argparse, subprocess
-from datetime import datetime, timedelta
-
-from xml.dom import minidom
+import glob
+import logging
+import math
+import os
+import re
+import sys
+from datetime import datetime
 from xml.etree import cElementTree as ET
-from osgeo import gdal, ogr, osr, gdalconst
+
+from osgeo import gdal, ogr, osr
 
 gdal.SetConfigOption('GDAL_PAM_ENABLED', 'NO')
 

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -213,6 +213,7 @@ def main():
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 task_handler.run_tasks(task_queue)
@@ -221,6 +222,7 @@ def main():
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 task_handler.run_tasks(task_queue)
@@ -229,6 +231,7 @@ def main():
             try:
                 run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_arg_keys)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
 
     else:
@@ -565,6 +568,7 @@ def run_mosaic(tile_builder_script, inpath, mosaicname, mosaic_dir, args, pos_ar
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 if task_handler.num_processes > 1:

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -1,10 +1,15 @@
-import os, sys, shutil, glob, re, tarfile, logging, argparse, subprocess, math
-from datetime import datetime, date, timedelta
-from xml.etree import cElementTree as ET
-from osgeo import gdal, ogr, osr, gdalconst
-import numpy
+#!/usr/bin/env python
 
-from lib import mosaic, utils, taskhandler
+import argparse
+import logging
+import math
+import os
+import sys
+from datetime import date, datetime
+
+from osgeo import ogr, osr
+
+from lib import mosaic, taskhandler, utils
 
 ### Create Logger
 logger = logging.getLogger("logger")

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -1,9 +1,16 @@
-import os, sys, shutil, glob, re, tarfile, logging, argparse
+#!/usr/bin/env python
 
-from lib import mosaic, utils, taskhandler
+import argparse
+import logging
+import os
+import shutil
+import sys
+
 import numpy
-from osgeo import gdal, ogr, osr, gdalconst
-    
+from osgeo import gdal
+
+from lib import mosaic, taskhandler, utils
+
 logger = logging.getLogger("logger")
 logger.setLevel(logging.DEBUG)
 

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -82,6 +82,7 @@ def main():
     try:
         dsp, lyrn = utils.get_source_names(src)
     except RuntimeError as e:
+        logger.error(utils.capture_error_trace())
         parser.error(e)
     if not os.path.isfile(csvpath):
         parser.error("Arg2 is not a valid file path: %s" %csvpath)
@@ -197,6 +198,7 @@ def main():
                     try:
                         HandleTile(t, src, dstdir, csvpath, args, exclude_list)
                     except RuntimeError as e:
+                        logger.error(utils.capture_error_trace())
                         logger.error(e)
     
     else:
@@ -208,6 +210,7 @@ def main():
                 try:
                     HandleTile(t, src, dstdir, csvpath, args, exclude_list)
                 except RuntimeError as e:
+                    logger.error(utils.capture_error_trace())
                     logger.error(e)
         
         

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -1,8 +1,15 @@
-import os, sys, logging, argparse, numpy, glob
-from datetime import datetime, date
-from osgeo import gdal, ogr, osr, gdalconst
+#!/usr/bin/env python
 
-from lib import ortho_functions, mosaic, utils, taskhandler
+import argparse
+import glob
+import logging
+import os
+import sys
+from datetime import date, datetime
+
+from osgeo import ogr, osr
+
+from lib import mosaic, ortho_functions, utils
 
 ### Create Logger
 logger = logging.getLogger("logger")

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -139,6 +139,7 @@ def main():
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -148,6 +149,7 @@ def main():
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -157,6 +159,7 @@ def main():
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 logger.info("Number of child processes to spawn: %i", task_handler.num_processes)
@@ -416,12 +419,14 @@ def calc_ndvi(srcfp, dstfp, args):
                     try:
                         os.remove(f)
                     except Exception as e:
+                        logger.error(utils.capture_error_trace())
                         logger.warning('Could not remove %s: %s', os.path.basename(f), e)
             if wd != dstdir:
                 for f in wd_files:
                     try:
                         os.remove(f)
                     except Exception as e:
+                        logger.error(utils.capture_error_trace())
                         logger.warning('Could not remove %s: %s', os.path.basename(f), e)
         else:
             logger.error("pgc_ndvi.py: %s was not created", dstfp_local)

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -1,8 +1,16 @@
-import os, sys, shutil, math, glob, re, tarfile, argparse, subprocess, logging
-from datetime import datetime, timedelta
-from osgeo import gdal, ogr, osr, gdalconst, numpy
+#!/usr/bin/env python
 
-from lib import ortho_functions, utils, taskhandler
+import argparse
+import logging
+import math
+import os
+import shutil
+import sys
+
+import numpy
+from osgeo import gdal
+
+from lib import ortho_functions, taskhandler, utils
 
 #### Create Loggers
 logger = logging.getLogger("logger")

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -248,6 +248,7 @@ def main():
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -257,6 +258,7 @@ def main():
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -266,6 +268,7 @@ def main():
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 logger.info("Number of child processes to spawn: %i", task_handler.num_processes)
@@ -289,6 +292,8 @@ def main():
 
                 if not args.dryrun:
                     results[task.name] = task.method(src, dstfp, task_arg_obj)
+                else:
+                    print(src)
 
                 #### remove existing file handler
                 logger.removeHandler(lfh)

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -1,9 +1,15 @@
+#!/usr/bin/env python
+
 from __future__ import division
 
-import os, sys, logging, argparse, math
-from datetime import datetime
+import argparse
+import logging
+import math
+import os
+import sys
 import xml.etree.ElementTree as ET
-from lib import ortho_functions, utils, taskhandler
+
+from lib import ortho_functions, taskhandler, utils
 from lib.taskhandler import argval2str
 
 #### Create Loggers

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -408,7 +408,7 @@ def main():
 
         task = taskhandler.Task(
             task_item_srcfn,
-            'Psh{:04g}'.format(i),
+            'Psh{:04g}'.format(job_count),
             'python',
             '{} {} {} {}'.format(
                 argval2str(scriptpath),

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -291,6 +291,7 @@ def main():
     try:
         spatial_ref = utils.SpatialRef(args.epsg)
     except RuntimeError as e:
+        logger.error(utils.capture_error_trace())
         parser.error(e)
 
     #### Verify that dem and ortho_height are not both specified
@@ -358,6 +359,7 @@ def main():
         try:
             image_pair = ImagePair(srcfp, spatial_ref)
         except RuntimeError as e:
+            logger.error(utils.capture_error_trace())
             logger.error(e)
         else:
             logger.info("Image: %s, Sensor: %s", image_pair.mul_srcfn, image_pair.sensor)
@@ -439,6 +441,7 @@ def main():
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath, l)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -448,6 +451,7 @@ def main():
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -457,6 +461,7 @@ def main():
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
             except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
                 logger.error(e)
             else:
                 logger.info("Number of child processes to spawn: %i", task_handler.num_processes)
@@ -607,6 +612,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
                 try:
                     os.remove(f)
                 except Exception as e:
+                    logger.error(utils.capture_error_trace())
                     logger.warning('Could not remove %s: %s', os.path.basename(f), e)
     
     if os.path.isfile(pansh_dstfp):

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -1,11 +1,21 @@
+#!/usr/bin/env python
+
 from __future__ import division
 
-import os, sys, shutil, math, glob, re, tarfile, argparse, subprocess, logging, platform
-from datetime import datetime, timedelta
+import argparse
+import glob
+import logging
+import math
+import os
+import platform
+import re
+import shutil
+import sys
 import xml.etree.ElementTree as ET
-from osgeo import gdal, ogr, osr, gdalconst
 
-from lib import ortho_functions, utils, taskhandler
+from osgeo import gdal, gdalconst, ogr, osr
+
+from lib import ortho_functions, taskhandler, utils
 from lib.taskhandler import argval2str
 
 #### Create Loggers


### PR DESCRIPTION
When an exception is handled like this:
```
try:
    some_function()
except RuntimeError as e:
    logger.error(e)
```
it can be difficult to troubleshoot the error when the error message `e` isn't helpful on its own.
(It's best to avoid catching the generic `RuntimeError` (or `Exception`) whenever possible, and catch a more specific type of error that you know the code might throw.)

If you don't want the code to re-raise the exception after printing out the error message, you can make use of the function `traceback.print_exec()` to print the full error trace when that would be helpful. The new `utils.capture_error_trace()` function is helpful in that it capture the output of `traceback.print_exec()` in a variable, which we can then hand off to `logger.error()`.