### PR TITLE
Updated pgc_ortho.py to check for existing .vrt files that are left b…

### DIFF
--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -284,6 +284,7 @@ def main():
 
         else:
 
+            ret_code = 0
             results = {}
             for task in task_queue:
 
@@ -309,9 +310,10 @@ def main():
             for k, v in results.items():
                 if v != 0:
                     logger.warning("Failed Image: %s", k)
-                    sys.exit(1)
+                    ret_code = 1
 
         logger.info("Done")
+        sys.exit(ret_code)
 
     else:
         logger.info("No images found to process")

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -192,8 +192,33 @@ def main():
             ortho_functions.formats[args.format]
         ))
 
-        done = os.path.isfile(dstfp)
-        if done is False:
+        # Must be a better way to check this
+        # Check to see if raw.vrt or vrt.vrt are present
+        vrtfile1 = os.path.join(dstdir, "{}_{}{}{}{}".format(
+            os.path.splitext(srcfn)[0],
+            bittype,
+            args.stretch,
+            spatial_ref.epsg,
+            "_raw.vrt"
+        ))
+
+        vrtfile2 = os.path.join(dstdir, "{}_{}{}{}{}".format(
+            os.path.splitext(srcfn)[0],
+            bittype,
+            args.stretch,
+            spatial_ref.epsg,
+            "_vrt.vrt"
+        ))
+
+        vrt_done = os.path.isfile(vrtfile1) or os.path.isfile(vrtfile2)
+        tif_done = os.path.isfile(dstfp)
+        # If no tif file present, need to make one
+        if tif_done is False:
+            i += 1
+            images_to_process.append(srcfp)
+
+        # If tif file is present but one of the vrt files is present, need to rebuild
+        elif tif_done is True and vrt_done is True:
             i += 1
             images_to_process.append(srcfp)
 
@@ -302,6 +327,7 @@ def main():
             for k, v in results.items():
                 if v != 0:
                     logger.warning("Failed Image: %s", k)
+                    sys.exit(1)
 
         logger.info("Done")
 


### PR DESCRIPTION
…ehind if ctrl-c is used to exit. If they are found that image is included in the list of images to process. Added sys.exit(1) at the end if an image fails (requested by Danny).

Update ortho_functions.py to delete all existing temp_files before it begins processing. To compensate I changed the --save-temps and --wd sections. Save temps now renames temp files to .save. Using the --wd argument will preserve all files in the local directory.