### PR TITLE
pgc_ortho.py new CSV argument list source type

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -655,9 +655,9 @@ def yield_task_args(task_list, script_args,
         test_task_nargs = len(test_task)
     else:
         test_task_nargs = 1
-        # If tasks are CSV argument lists and argname_1D is provided,
-        # we assume the CSV argument lists themselves can be provided as the
-        # indicated script argument.
+        # If tasks have a CSV file path as the single argument and argname_1D
+        # is provided, assume the CSV files themselves can be provided as the
+        # argname_1D script argument.
         if (    argname_2D_list is not None and len(argname_2D_list) != 1
             and test_task.endswith('.csv') and argname_1D is not None):
             argname_2D_list = [argname_1D]
@@ -675,7 +675,7 @@ def yield_task_args(task_list, script_args,
             argname_2D_list = [argname_1D]
 
     # Verify that the number of script argument names provided in argname_2D_list
-    # (or through argname_1D) matches the number of argument values in
+    # (or single argument from argname_1D) matches the number of argument values in
     # each row of the task_list.
     if len(argname_2D_list) != test_task_nargs:
         raise InvalidArgumentError(

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -61,7 +61,7 @@ class SpatialRef(object):
             raise RuntimeError("EPSG value must be an integer: {}".format(epsg))
         else:
             err = srs.ImportFromEPSG(epsgcode)
-            if err == 7:
+            if err != 0:
                 raise RuntimeError("Invalid EPSG code: {}".format(epsgcode))
             else:
                 proj4_string = srs.ExportToProj4()

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -43,6 +43,11 @@ def capture_error_trace():
     return caught_err
 
 
+class InvalidArgumentError(Exception):
+    def __init__(self, msg=""):
+        super(Exception, self).__init__(msg)
+
+
 class SpatialRef(object):
 
     def __init__(self, epsg):

--- a/qsub_ortho.sh
+++ b/qsub_ortho.sh
@@ -35,7 +35,7 @@ echo
 
 cd $PBS_O_WORKDIR
 
-module load gdal/2.1.3
+source ~/.bashrc; conda activate pgc
 
 echo $p1
 time eval $p1


### PR DESCRIPTION
To aid with complex processing tasks, such as those with many source images where groups of images require different output projections, you can provide a `*.csv` CSV file as the `src` argument to `pgc_ortho.py`.

The CSV file must have a header row listing the names of script arguments corresponding to the argument values for each task (each image to be processed) listed in the rows below. For `pgc_ortho.py`, the first column must be the absolute path to the source image, and the corresponding column header must be "src" (with or without quotes -- single and double quotes are stripped the ends of all CSV elements).

Not all script arguments need to be listed in the CSV file. Script arguments provided via command line that aren't overloaded from the CSV file will be passed like normal to each image processing task.

One issue is that parent argument parser in `ortho_functions.py` makes the `--epsg` argument required, so as a workaround if `src` is a CSV file, you can provide `--epsg 0` and as long as "epsg" is a field in the CSV file, it will let that pass. All unique EPSG codes in the CSV file are validated upfront using the `utils.SpatialRef` class.