### PR TITLE
Update regex in doesCross180() to accept lat/lon integer values, not just floats

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -484,7 +484,7 @@ def doesCross180(geom):
         raise RuntimeError(err)
 
     result = False
-    _mat = re.findall(r"-?\d+\.\d+", geom.ExportToWkt())
+    _mat = re.findall(r"-?\d+(?:\.\d+)?", geom.ExportToWkt())
     if _mat:
         x_coords = [float(lng) for (lng, lat) in [_mat[i:i+2] for i in range(0, len(_mat), 2)]]
         result = (max(x_coords) - min(x_coords)) > 180.0


### PR DESCRIPTION
I was hitting an error with the previous regex call in `re.findall()` when the longitude value was a whole number. The expression dropped those values and the function failed because there was an odd number of values when constructing `(lat, lon)` pairs for the `x_coords` object.  

I updated the expression based on the response [here](https://stackoverflow.com/questions/25170209/python-regex-for-float-or-int-while-not-splitting-the-float-into-two-floats), and it resolved the issue that I was hitting but I don't have much experience with regex so it might need another set of eyes to make sure there aren't any incorrect assumptions with the new expression.