### PR TITLE
Added gdalwarp --tap argument, couple bugfixes

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -1007,10 +1007,11 @@ def GetImageStats(args, info, target_extent_geom=None):
 
             info.stretch = args.stretch
             if args.stretch == 'au':
-                if (maxlat + minlat / 2) <= -60:
+                if ((maxlat + minlat) / 2) <= -60:
                     info.stretch = 'rf'
                 else:
                     info.stretch = 'mr'
+                logger.info("Automatically selected stretch: %s", info.stretch)
     else:
         logger.error("Cannot open dataset: %s", info.localsrc)
         rc = 1

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -24,7 +24,7 @@ DGbandList = ['BAND_P', 'BAND_C', 'BAND_B', 'BAND_G', 'BAND_Y', 'BAND_R', 'BAND_
               'BAND_S2', 'BAND_S3', 'BAND_S4', 'BAND_S5', 'BAND_S6', 'BAND_S7', 'BAND_S8']
 formats = {'GTiff': '.tif', 'JP2OpenJPEG': '.jp2', 'ENVI': '.envi', 'HFA': '.img', 'JPEG': '.jpg'}
 outtypes = ['Byte', 'UInt16', 'Float32']
-stretches = ["ns", "rf", "mr", "rd"]
+stretches = ["ns", "rf", "mr", "rd", "au"]
 resamples = ["near", "bilinear", "cubic", "cubicspline", "lanczos"]
 gtiff_compressions = ["jpeg95", "lzw"]
 exts = ['.ntf', '.tif']

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -285,7 +285,7 @@ def buildParentArgumentParser():
                         help="output pixel resolution in units of the projection")
     parser.add_argument("-c", "--stretch", choices=stretches, default="rf",
                         help="stretch type [ns: nostretch, rf: reflectance (default), mr: modified reflectance, rd: "
-                             "absolute radiance, au: automatically set]")
+                             "absolute radiance, au: automatically set (rf for images below 60S latitude, otherwise mr)]")
     parser.add_argument("--resample", choices=resamples, default="near",
                         help="resampling strategy - mimicks gdalwarp options")
     parser.add_argument("--tap", action="store_true", default=False,

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -243,7 +243,6 @@ def main():
         image_list = csv_arg_data
 
     ## Build task queue
-    i = 0
     images_to_process = []
     for task_args in utils.yield_task_args(image_list, args,
                                            argname_1D='src',
@@ -269,11 +268,9 @@ def main():
         # If no tif file present, need to make one
         # If tif file is present but one of the vrt files is present, need to rebuild
         if (not tif_done) or vrt_exists:
-            i += 1
             images_to_process.append(srcfp)
 
-    logger.info('Number of incomplete tasks: %i', i)
-
+    logger.info("Number of incomplete tasks: %i", len(images_to_process))
     if len(images_to_process) == 0:
         logger.info("No images found to process")
         sys.exit(0)


### PR DESCRIPTION
Fixed a math order of operations bug in automatic stretch option `--stretch='au'`, and re-enabled use of that option by adding 'au' to the list of `--stretch` choices.

pgc_pansharpen.py would throw unwarranted/misleading error messages, one for every panchromatic image in the source directory, such as this:
```
RuntimeError: Image does not match multispectral name pattern: WV03_20150520204559_104001000C4A2100_15MAY20204559-P1BS-500827654050_01_P001.ntf
```
I reworked the error-catching logic to filter out reporting panchromatic images that are part of matched pan/multi pairs. All unmatched images should still be reported.