### PR TITLE
Automatic output ortho/pansh EPSG settings

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -277,7 +277,8 @@ def buildParentArgumentParser():
                         help="GTiff compression type (default=lzw)")
     parser.add_argument("-p", "--epsg", required=False, type=str,
                         help="EPSG projection code for output files [int: EPSG code, "
-                             "'utm': closest UTM zone, 'auto': closest UTM zone or polar stereo]")
+                             "'utm': closest UTM zone, 'auto': closest UTM zone or polar stereo "
+                             "(polar stereo cutoff is at 60 N/S latitude)]")
     parser.add_argument("-d", "--dem",
                         help="the DEM to use for orthorectification (elevation values should be relative to the wgs84 "
                              "ellipoid")

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -274,8 +274,9 @@ def buildParentArgumentParser():
                         help="output to the given format (default=GTiff)")
     parser.add_argument("--gtiff-compression", choices=gtiff_compressions, default="lzw",
                         help="GTiff compression type (default=lzw)")
-    parser.add_argument("-p", "--epsg", required=True, type=int,
-                        help="epsg projection code for output files")
+    parser.add_argument("-p", "--epsg", required=False, type=str,
+                        help="EPSG projection code for output files [int: EPSG code, "
+                             "'utm': closest UTM zone, 'auto': closest UTM zone or polar stereo]")
     parser.add_argument("-d", "--dem",
                         help="the DEM to use for orthorectification (elevation values should be relative to the wgs84 "
                              "ellipoid")
@@ -366,14 +367,21 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
         utils.delete_temp_files([info.dstfp, info.rawvrt, info.warpfile, info.vrtfile])
 
     #### Verify EPSG
-    try:
-        spatial_ref = utils.SpatialRef(args.epsg)
-    except RuntimeError as e:
-        logger.error(utils.capture_error_trace())
-        logger.error("Invalid EPSG code: %i", args.epsg)
-        err = 1
+    # epsg argument could also be 'utm' or 'auto', handled in GetImageStats
+    if type(args.epsg) is int:
+        info.epsg = args.epsg
+        try:
+            spatial_ref = utils.SpatialRef(info.epsg)
+        except RuntimeError as e:
+            logger.error(utils.capture_error_trace())
+            logger.error("Invalid EPSG code: %i", info.epsg)
+            err = 1
+        else:
+            info.spatial_ref = spatial_ref
     else:
-        args.spatial_ref = spatial_ref
+        # Determine automatic epsg and srs in GetImageStats
+        info.epsg = None
+        info.spatial_ref = None
 
     #### Verify that dem and ortho_height are not both specified
     if args.dem is not None and args.ortho_height is not None:
@@ -459,7 +467,7 @@ def process_image(srcfp, dstfp, args, target_extent_geom=None):
     #### Check that DEM overlaps image
     if not err == 1:
         if args.dem and not args.skip_dem_overlap_check:
-            overlap = overlap_check(info.geometry_wkt, args.spatial_ref, args.dem)
+            overlap = overlap_check(info.geometry_wkt, info.spatial_ref, args.dem)
             if overlap is False:
                 err = 1
 
@@ -644,13 +652,75 @@ def stackIkBands(dstfp, members):
     return rc
 
 
+def GetEPSGFromLatLon(lat, lon, mode='auto'):
+    """
+    Get the EPSG code of the UTM or polar stereographic
+    projected coordinate system closest to the provided
+    point latitude and longitude.
+
+    Parameters
+    ----------
+    lat : float [-90, 90]
+        Point latitude in decimal degrees.
+    lon : float [-180, 180]
+        Point longitude in decimal degrees.
+    mode : str
+        If 'utm', use closest UTM zone.
+        If 'auto', use closest UTM zone when
+        `lat` is in the range [-60, 60], otherwise
+        use the proper polar stereographic projection.
+
+    Returns
+    -------
+    epsg_code : int
+        EPSG code of selected projected coordinate system.
+    """
+    mode_choices = ['utm', 'auto']
+
+    if -90 <= lat <= 90:
+        pass
+    else:
+        raise utils.InvalidArgumentError(
+            "`lat` must be in the range [-90, 90] but was {}".format(lat)
+        )
+    if -180 <= lon <= 180:
+        pass
+    else:
+        raise utils.InvalidArgumentError(
+            "`lon` must be in the range [-180, 180] but was {}".format(lon)
+        )
+    if mode not in mode_choices:
+        raise utils.InvalidArgumentError(
+            "`mode` must be one of {} but was '{}'".format(mode_choices, mode)
+        )
+
+    epsg_code = None
+
+    if mode == 'utm' or (mode == 'auto' and (-60 <= lat <= 60)):
+        utm_zone_num = max(1, math.ceil((lon - (-180)) / 6))
+        if lat >= 0:
+            epsg_code = 32600 + utm_zone_num
+        else:
+            epsg_code = 32700 + utm_zone_num
+
+    elif mode == 'auto':
+        if lat > 60:
+            epsg_code = 3413
+        elif lat < 60:
+            epsg_code = 3031
+
+    assert type(epsg_code) is int
+    return epsg_code
+
+
+
 def calcStats(args, info):
 
     logger.info("Calculating image with stats")
     rc = 0
 
     #### Get Well-known Text String of Projection from EPSG Code
-    p = args.spatial_ref.srs
+    p = info.spatial_ref.srs
     prj = p.ExportToWkt()
 
     imax = 2047.0
@@ -775,7 +845,7 @@ def calcStats(args, info):
         base_cmd,
         config_options,
         args.outtype,
-        args.spatial_ref.proj4,
+        info.spatial_ref.proj4,
         info.rgb_bands,
         co,
         args.format,
@@ -899,9 +969,27 @@ def GetImageStats(args, info, target_extent_geom=None):
         lr_geom = ogr.CreateGeometryFromWkt(lr)
         extent_geom = ogr.CreateGeometryFromWkt(poly_wkt)
 
+        #### Get geographic Envelope
+        minlon, maxlon, minlat, maxlat = extent_geom.GetEnvelope()
+
+        ## Determine output image projection if applicable
+        if type(args.epsg) is str:
+            cent_lat = (minlat + maxlat) / 2
+            cent_lon = (minlon + maxlon) / 2
+            info.epsg = GetEPSGFromLatLon(cent_lat, cent_lon, mode=args.epsg)
+            logger.info("Automatically selected output projection EPSG code: %d", info.epsg)
+            try:
+                spatial_ref = utils.SpatialRef(info.epsg)
+            except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
+                logger.error("Invalid EPSG code: %i", info.epsg)
+                rc = 1
+            else:
+                info.spatial_ref = spatial_ref
+
         #### Create srs objects
         s_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference(proj))
-        t_srs = args.spatial_ref.srs
+        t_srs = info.spatial_ref.srs
         g_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
         g_srs.ImportFromEPSG(WGS84)
         sg_ct = osr.CoordinateTransformation(s_srs, g_srs)
@@ -916,9 +1004,6 @@ def GetImageStats(args, info, target_extent_geom=None):
             lr_geom.Transform(sg_ct)
             extent_geom.Transform(sg_ct)
         logger.info("Geographic extent: %s", str(extent_geom))
-
-        #### Get geographic Envelope
-        minlon, maxlon, minlat, maxlat = extent_geom.GetEnvelope()
 
         #### Transform geoms to target srs
         if not g_srs.IsSame(t_srs):
@@ -1012,7 +1097,14 @@ def GetImageStats(args, info, target_extent_geom=None):
     return info, rc
 
 
-def GetImageGeometryInfo(src_image, spatial_ref):
+def GetImageGeometryInfo(src_image, spatial_ref, args, return_type='extent_geom'):
+    return_type_choices = ['extent_geom', 'epsg_code']
+    if return_type not in return_type_choices:
+        raise utils.InvalidArgumentError(
+            "`return_type` must be one of {} but was '{}'".format(
+                return_type_choices, return_type
+            )
+        )
 
     ds = gdal.Open(src_image, gdalconst.GA_ReadOnly)
     if ds is not None:
@@ -1076,6 +1168,26 @@ def GetImageGeometryInfo(src_image, spatial_ref):
 
         extent_geom = ogr.Geometry(ogr.wkbPolygon)
         extent_geom.AddGeometry(ring)
+
+        #### Get geographic Envelope
+        minlon, maxlon, minlat, maxlat = extent_geom.GetEnvelope()
+
+        ## Determine output image projection if applicable
+        if type(args.epsg) is str:
+            cent_lat = (minlat + maxlat) / 2
+            cent_lon = (minlon + maxlon) / 2
+            img_epsg = GetEPSGFromLatLon(cent_lat, cent_lon, mode=args.epsg)
+            try:
+                spatial_ref = utils.SpatialRef(img_epsg)
+            except RuntimeError as e:
+                logger.error(utils.capture_error_trace())
+                logger.error("Invalid EPSG code: %i", img_epsg)
+                return None
+        else:
+            img_epsg = args.epsg
+
+        if return_type == 'epsg_code':
+            return img_epsg
 
         #### Create srs objects
         s_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference(proj))
@@ -1316,7 +1428,7 @@ def WriteOutputMetadata(args, info):
     dMD["COMPRESSION"] = args.gtiff_compression
     #dMD["BANDNUMBER"]
     #dMD["BANDMAP"]
-    dMD["EPSG_CODE"] = str(args.epsg)
+    dMD["EPSG_CODE"] = str(info.epsg)
 
     pgcmd = ET.Element("PGC_IMD")
     for tag in dMD:
@@ -1451,7 +1563,7 @@ def WarpImage(args, info, gdal_thread_count=1):
                     info.centerlong,
                     info.extent,
                     info.res,
-                    args.spatial_ref.proj4,
+                    info.spatial_ref.proj4,
                     args.resample,
                     to,
                     info.rawvrt,
@@ -1470,7 +1582,7 @@ def WarpImage(args, info, gdal_thread_count=1):
                 config_options,
                 " ".join(nodata_list),
                 info.res,
-                args.spatial_ref.proj4,
+                info.spatial_ref.proj4,
                 args.resample,
                 info.rawvrt,
                 info.warpfile

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -252,6 +252,7 @@ def main():
         image_list = csv_arg_data
 
     ## Build task queue
+    i = 0
     images_to_process = []
     for task_args in utils.yield_task_args(image_list, args,
                                            argname_1D='src',

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -112,13 +112,22 @@ def main():
             os.makedirs(args.scratch)
 
     #### Verify EPSG
-    if srctype == 'csvfile' and args.epsg == 0:
+    spatial_ref = None
+    if srctype == 'csvfile' and args.epsg is None:
         # Check for valid EPSG argument in CSV argument list file
+        pass
+    elif args.epsg is None:
+        parser.error("--epsg argument is required")
+    elif args.epsg in ('utm', 'auto'):
+        # EPSG code is automatically determined in ortho_functions.GetImageStats function
         pass
     else:
         try:
+            args.epsg = int(args.epsg)
+        except ValueError:
+            parser.error("--epsg must be 'utm', 'auto', or an integer EPSG code")
+        try:
             spatial_ref = utils.SpatialRef(args.epsg)
-            args.epsg = spatial_ref.epsg
         except RuntimeError as e:
             parser.error(e)
 
@@ -194,7 +203,7 @@ def main():
                     invalid_epsg_code = True
             if invalid_epsg_code:
                 parser.error("Source CSV argument list file contains invalid EPSG code(s)")
-        elif args.epsg == 0:
+        elif args.epsg is None:
             parser.error("A valid EPSG argument must be specified")
 
         # Extract src image paths and send to utils.find_images
@@ -243,13 +252,16 @@ def main():
         image_list = csv_arg_data
 
     ## Build task queue
-    i = 0
     images_to_process = []
     for task_args in utils.yield_task_args(image_list, args,
                                            argname_1D='src',
                                            argname_2D_list=csv_header_argname_list):
         srcfp = task_args.src
         dstdir = task_args.dst
+
+        if type(task_args.epsg) is str:
+            task_args.epsg = ortho_functions.GetImageGeometryInfo(srcfp, spatial_ref, args,
+                                                                  return_type='epsg_code')
 
         srcdir, srcfn = os.path.split(srcfp)
         dst_basename = os.path.join(dstdir, "{}_{}{}{}".format(
@@ -309,6 +321,9 @@ def main():
         srcdir, srcfn = os.path.split(srcfp)
 
         if task_srcfp_list is images_to_process:
+            if type(task_args.epsg) is str:
+                task_args.epsg = ortho_functions.GetImageGeometryInfo(srcfp, spatial_ref, args,
+                                                                      return_type='epsg_code')
             dstfp = os.path.join(dstdir, "{}_{}{}{}{}".format(
                 os.path.splitext(srcfn)[0],
                 utils.get_bit_depth(task_args.outtype),

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -58,7 +58,7 @@ dRegExs = {
 
 class ImagePair(object):
     
-    def __init__(self, mul_srcfp, spatial_ref):
+    def __init__(self, mul_srcfp, spatial_ref, args):
         self.mul_srcfp = mul_srcfp
         self.srcdir, self.mul_srcfn = os.path.split(mul_srcfp)
         
@@ -77,8 +77,8 @@ class ImagePair(object):
                 raise RuntimeError("Corresponding panchromatic image not found: {}".format(self.mul_srcfp))
             else:
             ## get extent info for both images and calc intersect
-                mul_extent = self._get_image_info(self.mul_srcfp, spatial_ref)
-                pan_extent = self._get_image_info(self.pan_srcfp, spatial_ref)
+                mul_extent = self._get_image_info(self.mul_srcfp, spatial_ref, args)
+                pan_extent = self._get_image_info(self.pan_srcfp, spatial_ref, args)
                 self.intersection_geom = mul_extent.Intersection(pan_extent)
                 # print(mul_extent)
                 # print(mul_extent.Contains(pan_extent))
@@ -115,13 +115,14 @@ class ImagePair(object):
 
         return pan_name
     
-    def _get_image_info(self, src_image, spatial_ref):
+    def _get_image_info(self, src_image, spatial_ref, args):
 
         if self.sensor == 'IK01' and "_msi_" in src_image and not os.path.isfile(src_image):
             src_image_name = os.path.basename(src_image).replace("_msi_", "_blu_")
             src_image = os.path.join(self.srcdir, src_image_name)
 
-        return ortho_functions.GetImageGeometryInfo(src_image, spatial_ref)
+        return ortho_functions.GetImageGeometryInfo(src_image, spatial_ref, args,
+                                                    return_type='extent_geom')
 
 
 def main():
@@ -212,11 +213,22 @@ def main():
             os.makedirs(args.scratch)
 
     #### Verify EPSG
-    try:
-        spatial_ref = utils.SpatialRef(args.epsg)
-    except RuntimeError as e:
-        logger.error(utils.capture_error_trace())
-        parser.error(e)
+    spatial_ref = None
+    if args.epsg is None:
+        parser.error("--epsg argument is required")
+    elif args.epsg in ('utm', 'auto'):
+        # EPSG code is automatically determined in ortho_functions.GetImageStats
+        # and ortho_functions.GetImageGeometryInfo functions.
+        pass
+    else:
+        try:
+            args.epsg = int(args.epsg)
+        except ValueError:
+            parser.error("--epsg must be 'utm', 'auto', or an integer EPSG code")
+        try:
+            spatial_ref = utils.SpatialRef(args.epsg)
+        except RuntimeError as e:
+            parser.error(e)
 
     #### Verify that dem and ortho_height are not both specified
     if args.dem is not None and args.ortho_height is not None:
@@ -281,7 +293,7 @@ def main():
     for srcfp in image_list1:
         #print(srcfp)
         try:
-            image_pair = ImagePair(srcfp, spatial_ref)
+            image_pair = ImagePair(srcfp, spatial_ref, args)
         except RuntimeError as e:
             logger.error(utils.capture_error_trace())
             logger.error(e)
@@ -295,12 +307,18 @@ def main():
     i = 0
     pairs_to_process = []
     for image_pair in pair_list:
+
+        if type(args.epsg) is str:
+            img_epsg = ortho_functions.GetImageGeometryInfo(image_pair.mul_srcfp, spatial_ref, args,
+                                                            return_type='epsg_code')
+        else:
+            img_epsg = args.epsg
         
         pansh_dstfp = os.path.join(dstdir, "{}_{}{}{}_pansh.tif".format(
             os.path.splitext(image_pair.mul_srcfn)[0],
             bittype,
             args.stretch,
-            args.epsg
+            img_epsg
         ))
 
         done = os.path.isfile(pansh_dstfp)
@@ -328,11 +346,16 @@ def main():
 
         if not tasklist_is_text_bundles:
             image_pair = task_item
+            if type(args.epsg) is str:
+                img_epsg = ortho_functions.GetImageGeometryInfo(image_pair.mul_srcfp, spatial_ref, args,
+                                                                return_type='epsg_code')
+            else:
+                img_epsg = args.epsg
             pansh_dstfp = os.path.join(dstdir, "{}_{}{}{}_pansh.tif".format(
                 os.path.splitext(image_pair.mul_srcfn)[0],
                 bittype,
                 args.stretch,
-                args.epsg
+                img_epsg
             ))
             task_item_srcfp = image_pair.mul_srcfp
             task_item_srcfn = image_pair.mul_srcfn
@@ -452,17 +475,23 @@ def exec_pansharpen(image_pair, pansh_dstfp, args):
     else:
         dem_arg = ""
 
+    if type(args.epsg) is str:
+        img_epsg = ortho_functions.GetImageGeometryInfo(image_pair.mul_srcfp, None, args,
+                                                        return_type='epsg_code')
+    else:
+        img_epsg = args.epsg
+
     bittype = utils.get_bit_depth(args.outtype)
     pan_basename = os.path.splitext(image_pair.pan_srcfn)[0]
     mul_basename = os.path.splitext(image_pair.mul_srcfn)[0]
-    pan_local_dstfp = os.path.join(wd, "{}_{}{}{}.tif".format(pan_basename, bittype, args.stretch, args.epsg))
-    mul_local_dstfp = os.path.join(wd, "{}_{}{}{}.tif".format(mul_basename, bittype, args.stretch, args.epsg))
-    pan_dstfp = os.path.join(dstdir, "{}_{}{}{}.tif".format(pan_basename, bittype, args.stretch, args.epsg))
-    mul_dstfp = os.path.join(dstdir, "{}_{}{}{}.tif".format(mul_basename, bittype, args.stretch, args.epsg))
-    pansh_tempfp = os.path.join(wd, "{}_{}{}{}_pansh_temp.tif".format(mul_basename, bittype, args.stretch, args.epsg))
-    pansh_local_dstfp = os.path.join(wd, "{}_{}{}{}_pansh.tif".format(mul_basename, bittype, args.stretch, args.epsg))
-    pansh_xmlfp = os.path.join(dstdir, "{}_{}{}{}_pansh.xml".format(mul_basename, bittype, args.stretch, args.epsg))
-    mul_xmlfp = os.path.join(dstdir, "{}_{}{}{}.xml".format(mul_basename, bittype, args.stretch, args.epsg))
+    pan_local_dstfp = os.path.join(wd, "{}_{}{}{}.tif".format(pan_basename, bittype, args.stretch, img_epsg))
+    mul_local_dstfp = os.path.join(wd, "{}_{}{}{}.tif".format(mul_basename, bittype, args.stretch, img_epsg))
+    pan_dstfp = os.path.join(dstdir, "{}_{}{}{}.tif".format(pan_basename, bittype, args.stretch, img_epsg))
+    mul_dstfp = os.path.join(dstdir, "{}_{}{}{}.tif".format(mul_basename, bittype, args.stretch, img_epsg))
+    pansh_tempfp = os.path.join(wd, "{}_{}{}{}_pansh_temp.tif".format(mul_basename, bittype, args.stretch, img_epsg))
+    pansh_local_dstfp = os.path.join(wd, "{}_{}{}{}_pansh.tif".format(mul_basename, bittype, args.stretch, img_epsg))
+    pansh_xmlfp = os.path.join(dstdir, "{}_{}{}{}_pansh.xml".format(mul_basename, bittype, args.stretch, img_epsg))
+    mul_xmlfp = os.path.join(dstdir, "{}_{}{}{}.xml".format(mul_basename, bittype, args.stretch, img_epsg))
     
     if not os.path.isdir(wd):
         os.makedirs(wd)

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -120,84 +120,8 @@ class ImagePair(object):
         if self.sensor == 'IK01' and "_msi_" in src_image and not os.path.isfile(src_image):
             src_image_name = os.path.basename(src_image).replace("_msi_", "_blu_")
             src_image = os.path.join(self.srcdir, src_image_name)
-    
-        ds = gdal.Open(src_image, gdalconst.GA_ReadOnly)
-        if ds is not None:
-    
-            ####  Get extent from GCPs
-            num_gcps = ds.GetGCPCount()
-    
-            if num_gcps == 4:
-                gcps = ds.GetGCPs()
-                proj = ds.GetGCPProjection()
-    
-                gcp_dict = {}
-                id_dict = {"UpperLeft": 1,
-                           "1": 1,
-                           "UpperRight": 2,
-                           "2": 2,
-                           "LowerLeft": 4,
-                           "4": 4,
-                           "LowerRight": 3,
-                           "3": 3}
-    
-                for gcp in gcps:
-                    gcp_dict[id_dict[gcp.Id]] = [float(gcp.GCPPixel), float(gcp.GCPLine), float(gcp.GCPX),
-                                                 float(gcp.GCPY), float(gcp.GCPZ)]
-                ulx = gcp_dict[1][2]
-                uly = gcp_dict[1][3]
-                urx = gcp_dict[2][2]
-                ury = gcp_dict[2][3]
-                llx = gcp_dict[4][2]
-                lly = gcp_dict[4][3]
-                lrx = gcp_dict[3][2]
-                lry = gcp_dict[3][3]
-    
-                xsize = gcp_dict[1][0] - gcp_dict[2][0]
-                ysize = gcp_dict[1][1] - gcp_dict[4][1]
-    
-            else:
-                xsize = ds.RasterXSize
-                ysize = ds.RasterYSize
-                proj = ds.GetProjectionRef()
-                gtf = ds.GetGeoTransform()
-    
-                ulx = gtf[0] + 0 * gtf[1] + 0 * gtf[2]
-                uly = gtf[3] + 0 * gtf[4] + 0 * gtf[5]
-                urx = gtf[0] + xsize * gtf[1] + 0 * gtf[2]
-                ury = gtf[3] + xsize * gtf[4] + 0 * gtf[5]
-                llx = gtf[0] + 0 * gtf[1] + ysize * gtf[2]
-                lly = gtf[3] + 0 * gtf[4] + ysize * gtf[5]
-                lrx = gtf[0] + xsize * gtf[1] + ysize* gtf[2]
-                lry = gtf[3] + xsize * gtf[4] + ysize * gtf[5]
-    
-            ds = None
-    
-            ####  Create geometry objects
-            ring = ogr.Geometry(ogr.wkbLinearRing)
-            ring.AddPoint(ulx, uly)
-            ring.AddPoint(urx, ury)
-            ring.AddPoint(lrx, lry)
-            ring.AddPoint(llx, lly)
-            ring.AddPoint(ulx, uly)
 
-            extent_geom = ogr.Geometry(ogr.wkbPolygon)
-            extent_geom.AddGeometry(ring)
-    
-            #### Create srs objects
-            s_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference(proj))
-            t_srs = spatial_ref.srs
-            st_ct = osr.CoordinateTransformation(s_srs, t_srs)
-    
-            #### Transform geoms to target srs
-            if not s_srs.IsSame(t_srs):
-                extent_geom.Transform(st_ct)
-            #logger.info("Projected extent: %s", str(extent_geom))
-            return extent_geom
-                   
-        else:
-            logger.error("Cannot open dataset: %s", src_image)
-            return None
+        return ortho_functions.GetImageGeometryInfo(src_image, spatial_ref)
 
 
 def main():

--- a/qsub_ndvi.sh
+++ b/qsub_ndvi.sh
@@ -35,7 +35,7 @@ echo
 
 cd $PBS_O_WORKDIR
 
-module load gdal/2.1.3
+source ~/.bashrc; conda activate pgc
 
 echo $p1
 time eval $p1

--- a/qsub_pansharpen.sh
+++ b/qsub_pansharpen.sh
@@ -35,7 +35,7 @@ echo
 
 cd $PBS_O_WORKDIR
 
-module load gdal/2.1.3
+source ~/.bashrc; conda activate pgc
 
 echo $p1
 time eval $p1


### PR DESCRIPTION
FYI @clairecporter

Adds 'auto' and 'utm' options to the `--epsg` argument.
`'utm': closest UTM zone, 'auto': closest UTM zone or polar stereo`

Adding this was trickier than I expected, mostly due to the unforeseen need to determine each source image's target EPSG code in the initial check for incomplete processing tasks (because the epsg code is part of the output ortho/pansh image filename). In order to do this, I relocated a big chunk of code that analyzes target image geometry from `pgc_pansharpen.py` into `lib/ortho_functions.py` to avoid code duplication.

@bagl0025 and @bakkerbakker:  If either of you find a good chance to test out this branch (with or without using the new capability of the `--epsg` argument), it would be great to have some additional testing. I believe I've tested most all of the different option combinations on images in different geographic locations, but it'd be great to have some additional testing to make sure nothing broke. Thanks!