### PR TITLE
Miscellaneous fixes

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -9,12 +9,16 @@ import re
 import sys
 import traceback
 from datetime import datetime
-from collections.abc import Collection
 from io import StringIO
 from xml.etree import cElementTree as ET
 
 import numpy as np
 from osgeo import gdal, ogr, osr
+
+try:
+    import collections.abc as collectionsAbc
+except ImportError:
+    import collections as collectionsAbc
 
 gdal.SetConfigOption('GDAL_PAM_ENABLED', 'NO')
 
@@ -655,7 +659,7 @@ def yield_task_args(task_list, script_args,
         object, yielded for each task in `task_list`.
     """
     test_task = task_list[0]
-    if isinstance(test_task, Collection) and not isinstance(test_task, str):
+    if isinstance(test_task, collectionsAbc.Iterable) and not isinstance(test_task, str):
         test_task_nargs = len(test_task)
     else:
         test_task_nargs = 1
@@ -699,7 +703,7 @@ def yield_task_args(task_list, script_args,
         # or could be a 2D list or NumPy array of argument values.
         # Convert 1D single-argument task to the multiple-argument
         # structure (a list with a single argument) for code simplicity.
-        if isinstance(task, Collection) and not isinstance(task, str):
+        if isinstance(task, collectionsAbc.Iterable) and not isinstance(task, str):
             task_arg_list = task
         else:
             task_arg_list = [task]

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -484,9 +484,13 @@ def doesCross180(geom):
         raise RuntimeError(err)
 
     result = False
-    _mat = re.findall(r"-?\d+(?:\.\d+)?", geom.ExportToWkt())
-    if _mat:
-        x_coords = [float(lng) for (lng, lat) in [_mat[i:i+2] for i in range(0, len(_mat), 2)]]
+
+    # Get an array of the longitudes of all the points of all the rings in the polygon
+    x_coords = []
+    for ring in geom:
+        for pt in range(0, ring.GetPointCount()):
+            x_coords.append(ring.GetX(pt))
+    if x_coords:
         result = (max(x_coords) - min(x_coords)) > 180.0
 
     return result

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -233,7 +233,7 @@ def main():
             dem_filesz_gb = total_dem_filesz_gb
         else:
             dem_filesz_gb = os.path.getsize(args.dem) / 1024.0 / 1024 / 1024
-        pbs_req_mem_gb = int(min(50, max(4, math.ceil(dem_filesz_gb) + 2)))
+        pbs_req_mem_gb = int(min(50, max(8, math.ceil(dem_filesz_gb) + 2)))
         args.l = 'mem={}gb'.format(pbs_req_mem_gb)
 
     ## Group Ikonos

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -252,8 +252,7 @@ def main():
                 dem_filesz_gb = total_dem_filesz_gb
             else:
                 dem_filesz_gb = os.path.getsize(args.dem) / 1024.0 / 1024 / 1024
-
-            pbs_req_mem_gb = int(max(math.ceil(dem_filesz_gb) + 4, 8))
+            pbs_req_mem_gb = int(min(50, max(8, math.ceil(dem_filesz_gb) + 2)))
             args.l = 'mem={}gb'.format(pbs_req_mem_gb)
         
     ## Check GDAL version (2.1.0 minimum)

--- a/qsub_mosaic.sh
+++ b/qsub_mosaic.sh
@@ -5,6 +5,7 @@
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q batch
 
 echo ________________________________________________________
 echo

--- a/qsub_ndvi.sh
+++ b/qsub_ndvi.sh
@@ -4,6 +4,7 @@
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q batch
 
 echo ________________________________________________________
 echo

--- a/qsub_ortho.sh
+++ b/qsub_ortho.sh
@@ -4,6 +4,7 @@
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q batch
 
 echo ________________________________________________________
 echo

--- a/qsub_pansharpen.sh
+++ b/qsub_pansharpen.sh
@@ -4,6 +4,7 @@
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q batch
 
 echo ________________________________________________________
 echo


### PR DESCRIPTION
- Argument paths that need to be wrapped in quotes (particularly those containing spaces) were using a deficient strategy to escape the quotes when passing the Python "task command" for running through `taskhandler`. Changed to a new strategy that should be less prone to error in the future.
- Changed `doesCross180` method of retrieving geometry point coordinates from old regex parsing of the WKT string to a more robust method of retrieving the coordinates through GDAL methods. The new method passes `tests/unit_test_utils.py`. Thanks @klassenjs!
- Usage of the `collections` module in the `utils.yield_task_args` method is now backwards-compatible with Python2 so that we can test issues with Nunatak job scheduler that may be present when running with a Python3/GDAL3 Conda environment but not present when using the old `module load gdal/2.1.3` environment.