### PR TITLE
Fix bug where float32 outputs are integer values on pgc_ortho.py

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -805,7 +805,7 @@ def calcStats(args, info):
                                     '   <DstRect xOff="0" yOff="0" xSize="{3}" ySize="{4}"/>'
                                     '</ComplexSource>)'.format(info.warpfile, band, LUT, xsize, ysize))
 
-                vds.GetRasterBand(band).SetMetadataItem("source_0", ComplexSourceXML, "new_vrt_sources")
+                vds.GetRasterBand(band).SetMetadataItem("source_0", ComplexSourceXML, "vrt_sources")
                 vds.GetRasterBand(band).SetNoDataValue(0)
                 if vds.GetRasterBand(band).GetColorInterpretation() == gdalconst.GCI_AlphaBand:
                     vds.GetRasterBand(band).SetColorInterpretation(gdalconst.GCI_Undefined)
@@ -1578,7 +1578,7 @@ def WarpImage(args, info, gdal_thread_count=1):
 
 
                 #### GDALWARP Command
-                cmd = 'gdalwarp {} -srcnodata "{}" -of GTiff -ot UInt16 {}{}{}{}-co "TILED=YES" -co "BIGTIFF=IF_SAFER" ' \
+                cmd = 'gdalwarp {} -srcnodata "{}" -of GTiff -ot Float32 {}{}{}{}-co "TILED=YES" -co "BIGTIFF=IF_SAFER" ' \
                       '-t_srs "{}" -r {} -et 0.01 -rpc -to "{}" "{}" "{}"'.format(
                     config_options,
                     " ".join(nodata_list),

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -190,8 +190,9 @@ def convert_optional_args_to_string(args, positional_arg_keys, arg_keys_to_remov
             k = k.replace('_', '-')
             if isinstance(v, (list, tuple)):
                 arg_list.append("--{} {}".format(k, ' '.join([argval2str(item) for item in v])))
-            elif isinstance(v, bool):
-                if v is True:
+                if len(k) == 1:
+                    arg_list.append("-{}".format(k))
+                else:
                     arg_list.append("--{}".format(k))
             else:
                 arg_list.append("--{} {}".format(k, argval2str(v)))


### PR DESCRIPTION
The warping step of pgc_ortho uses a UInt16 bit depth like the original raster.  Using CreateCopy, the VRT driver in GDAL forces the VRT to that same datatype and truncates the floating point values.  I fixed this by casting the warp image to floating point.  It's not an elegant solution since it makes the temp warp file larger than necessary, but it will work.

Also fixed a bug in the VRT creation where the source dataset was being written twice to the same output.  The bug likely had little impact.