### PR TITLE
add option to write input command to txt file next to output dir

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -321,6 +321,8 @@ def buildParentArgumentParser():
                              '--pbs/--slurm will only accept 1 thread.'
                         .format(ARGDEF_THREADS, ARGDEF_CPUS_AVAIL),
                         default=ARGDEF_THREADS)
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
+                        help='Skip writing the txt file containing the input command.')
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
 
     return parser, pos_arg_keys

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -934,3 +934,15 @@ def subset_vrt_dem(csv_arg_data, csv_header_argname_list, script_args):
             subset_vrt_fp.write(vrt_contents_suffix)
 
     return csv_arg_data_trimmed
+
+def write_input_command_txt(arg_str, dst_dir):
+    logger.info("Processing command: {}".format(arg_str))
+    now = datetime.now()
+    base_cmd = os.path.splitext(os.path.basename(arg_str.split()[0]))[0]
+    txt_fn = "{}_command_{}.txt".format(base_cmd, now.strftime("%Y%m%d_%H%M%S"))
+    txt_fp = os.path.join(os.path.abspath(os.path.join(dst_dir, os.pardir)),txt_fn)
+    try:
+        with open(txt_fp, 'w') as f:
+            f.write(arg_str)
+    except:
+        logger.error("Could not write command reference text file")

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -94,6 +94,8 @@ def main():
                         help="PBS resources requested (mimicks qsub syntax). Use only on HPC systems.")
     parser.add_argument("--log",
                         help="file to log progress (default is <output dir>\{}".format(default_logfile))
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
+                        help='Skip writing the txt file containing the input command.')
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
 
     
@@ -174,6 +176,13 @@ def main():
             parser.error("Supplied year {0} is not valid, or its format is incorrect; should be 4 digits for single "
                          "year (e.g., 2017), eight digits and dash for range (e.g., 2015-2017)".format(args.tyear))
             sys.exit(1)
+
+    # write input command to text file next to output folder for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+    if not args.skip_cmd_txt and not args.dryrun:
+        utils.write_input_command_txt(command_str,mosaic_dir)
+        args.skip_cmd_txt = True
 
     #### Get exclude list if specified
     if args.exclude is not None:

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -68,6 +68,8 @@ def main():
                         help="build shapefile of intersecting images (only invoked if --no_sort is not used)")
     parser.add_argument("--require-pan", action='store_true', default=False,
                         help="limit search to imagery with both a multispectral and a panchromatic component")
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
+                        help='Skip writing the txt file containing the input command.')
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
 
  
@@ -133,6 +135,13 @@ def main():
             parser.error("Supplied year {0} is not valid, or its format is incorrect; should be 4 digits for single "
                          "year (e.g., 2017), eight digits and dash for range (e.g., 2015-2017)".format(args.tyear))
             sys.exit(1)
+
+    # write input command to text file next to output folder for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+    if not args.skip_cmd_txt and not args.dryrun:
+        utils.write_input_command_txt(command_str,dstdir)
+        args.skip_cmd_txt = True
 
     ##### Configure Logger
     if args.log is not None:

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -46,6 +46,8 @@ def main():
                         help="submission script to use in PBS/SLURM submission (PBS default is qsub_ndvi.sh, SLURM "
                              "default is slurm_ndvi.py, in script root folder)")
     parser.add_argument("-l", help="PBS resources requested (mimicks qsub syntax, PBS only)")
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
+                        help='Skip writing the txt file containing the input command.')
     parser.add_argument("--dryrun", action="store_true", default=False,
                         help="print actions without executing")
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
@@ -89,6 +91,13 @@ def main():
         parser.error("Options --pbs and --slurm are mutually exclusive")
     if (args.pbs or args.slurm) and args.parallel_processes > 1:
         parser.error("HPC Options (--pbs or --slurm) and --parallel-processes > 1 are mutually exclusive")
+
+    # write input command to text file next to output folder for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+    if not args.skip_cmd_txt and not args.dryrun:
+        utils.write_input_command_txt(command_str,dstdir)
+        args.skip_cmd_txt = True
 
     #### Set concole logging handler
     lso = logging.StreamHandler()

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -152,6 +152,13 @@ def main():
                     "'ALL_CPUS'".format(requested_threads, ortho_functions.ARGDEF_CPUS_AVAIL))
         args.threads = 'ALL_CPUS'
 
+    # write input command to text file next to output folder for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+    if not args.skip_cmd_txt and not args.dryrun:
+        utils.write_input_command_txt(command_str,dstdir)
+        args.skip_cmd_txt = True
+
     #### Get args ready to pass to task handler
     arg_keys_to_remove = ('l', 'qsubscript', 'dryrun', 'pbs', 'slurm', 'parallel_processes', 'tasks_per_job')
 

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -317,7 +317,14 @@ def main():
         logger.info("threads requested ({0}) exceeds number available on system ({1}), setting thread count to "
                     "'ALL_CPUS'".format(requested_threads, ortho_functions.ARGDEF_CPUS_AVAIL))
         args.threads = 'ALL_CPUS'
-    
+
+    # write input command to text file next to output folder for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+    if not args.skip_cmd_txt and not args.dryrun:
+        utils.write_input_command_txt(command_str,dstdir)
+        args.skip_cmd_txt = True
+
     #### Get args ready to pass to task handler
     arg_keys_to_remove = ('l', 'qsubscript', 'dryrun', 'pbs', 'slurm', 'parallel_processes', 'tasks_per_job')
     arg_str_base = taskhandler.convert_optional_args_to_string(args, pos_arg_keys, arg_keys_to_remove)


### PR DESCRIPTION
Added a function to lib.utils to write the input CLI command to a text file next to the output directory for reference, upon request from the User Services team to have a copy of the inputs persist. I added an argument to skip this behavior and made it so that cluster jobs will only generate a command txt file for the initial input, not each individual job.