### PR TITLE
Add functionality for accepting ESRI codes in the EPSG arg

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -61,9 +61,15 @@ class SpatialRef(object):
         except ValueError:
             raise RuntimeError("EPSG value must be an integer: {}".format(epsg))
         else:
-            err = srs.ImportFromEPSG(epsgcode)
+            # test epsg code
+            err = srs.SetFromUserInput("EPSG:{}".format(epsgcode))
             if err != 0:
-                raise RuntimeError("Invalid EPSG code: {}".format(epsgcode))
+                # test esri code
+                err = srs.SetFromUserInput("ESRI:{}".format(epsgcode))
+                if err != 0:
+                    raise RuntimeError("Invalid EPSG/ERSI code: {}".format(epsgcode))
+                else:
+                    proj4_string = srs.ExportToProj4()
             else:
                 proj4_string = srs.ExportToProj4()
 


### PR DESCRIPTION
This change allows users to input an ESRI code (like the Canada Albers Equal Area Conic projection (https://epsg.io/102001) that was required by a user) in the `--epsg` argument in `pgc_ortho.py`. Additional functionality to pass in a `proj4` string or other format to define an `srs` object can be added in the future, leveraging the `srs.SetFromUserInput()` method described [here](https://gdal.org/doxygen/classOGRSpatialReference.html#aec3c6a49533fe457ddc763d699ff8796).