### PR TITLE
Set SLURM job log filenames to match PBS job log filenames

### DIFF
--- a/slurm_mosaic.sh
+++ b/slurm_mosaic.sh
@@ -7,8 +7,8 @@
 #SBATCH -c 32
 
 # job log path
-#SBATCH -o slurm.%N.%j.out
-#SBATCH -e slurm.%N.%j.err
+#SBATCH -o %x.o%j
+#SBATCH -e %x.o%j
 
 echo ________________________________________
 echo

--- a/slurm_ndvi.sh
+++ b/slurm_ndvi.sh
@@ -7,8 +7,8 @@
 #SBATCH -c 2
 
 # job log path
-#SBATCH -o slurm.%N.%j.out
-#SBATCH -e slurm.%N.%j.err
+#SBATCH -o %x.o%j
+#SBATCH -e %x.o%j
 
 echo ________________________________________
 echo

--- a/slurm_ortho.sh
+++ b/slurm_ortho.sh
@@ -7,8 +7,8 @@
 #SBATCH -c 2
 
 # job log path
-#SBATCH -o slurm.%N.%j.out
-#SBATCH -e slurm.%N.%j.err
+#SBATCH -o %x.o%j
+#SBATCH -e %x.o%j
 
 echo ________________________________________
 echo

--- a/slurm_pansharpen.sh
+++ b/slurm_pansharpen.sh
@@ -7,8 +7,8 @@
 #SBATCH -c 2
 
 # job log path
-#SBATCH -o slurm.%N.%j.out
-#SBATCH -e slurm.%N.%j.err
+#SBATCH -o %x.o%j
+#SBATCH -e %x.o%j
 
 echo ________________________________________
 echo


### PR DESCRIPTION
These changes have the stdout and stderr streams combined in a single logfile named `{JOBNAME}.o{JOBID}`, as we had with PBS on Nunatak.