### PR TITLE
Fix: Assign NoData to a value outside of the valid data range for outputs of pgc_ortho.py and pgc_pansharpen.py

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -829,7 +829,7 @@ def calcStats(args, info):
                                     '</ComplexSource>)'.format(info.warpfile, band, LUT, xsize, ysize))
 
                 vds.GetRasterBand(band).SetMetadataItem("source_0", ComplexSourceXML, "vrt_sources")
-                vds.GetRasterBand(band).SetNoDataValue(0)
+                vds.GetRasterBand(band).SetNoDataValue(65535) # NoData hardcoded here
                 if vds.GetRasterBand(band).GetColorInterpretation() == gdalconst.GCI_AlphaBand:
                     vds.GetRasterBand(band).SetColorInterpretation(gdalconst.GCI_Undefined)
         else:


### PR DESCRIPTION
I have tried two (cumulative) code changes to attempt to address the NoData issue (#73) for the subset of test images at `V:\pgc\data\common\quickbase\2204_UW_Andresen_Alaska_2023\imagery_check`. 

## Attempt 1 - Modify the WarpImage function

I modified the `lib.ortho_functions.WarpImage` function to assign a NoData value to the destination file based on the specified data type of the destination file.  

I ran a test batch using the following command.

```bash
python pgc_ortho.py \
    --epsg=utm \
    --stretch rf \
    --outtype UInt16 \
    --dem /mnt/pgc/data/elev/dem/copernicus-dem-30m/mosaic/global/cop30_tiles_global_wgs84-height_windows.vrt \
    --format GTiff \
    --save-temps \
    /mnt/pgc/data/common/quickbase/2204_UW_Andresen_Alaska_2023/imagery_check/renamed \
    /mnt/pgc/data/common/quickbase/2204_UW_Andresen_Alaska_2023/imagery_check/ortho-16-rf-noDataTest
```
Note that I specified the wrong `--dem` VRT for the platform I was running on (WSL). The process complained that it couldn't find the reference rasters and thus the valid cell values aren't what they should be, but the NoData values behaved as expected for the output of this function.

The change successfully set the NoData value to `65535` for the intermediate images that this function produces, `ortho-16-rf-noDataTest/*_warp.tif.save`. However, the final images, `ortho-16-rf-noDataTest/*.tif` still end up with a NoData value of `0`.

## Attempt 2 - Modify the calcStats function

I modified `lib.ortho_functions.calcStats`, the function responsible for applying the stretch corrections. This is what is called on the warped image to produce the final output. I changed the hardcoded value passed to `vds.GetRasterBand(band).SetNoDataValue(0)` from `0` to `65535` as that is what the incoming and outgoing NoData value should be for this specific set of images.

I ran another test batch with the following command; fixing the `--dem` option.

```bash
python pgc_ortho.py \
    --epsg=utm \
    --stretch rf \
    --outtype UInt16 \
    --dem /mnt/pgc/data/elev/dem/copernicus-dem-30m/mosaic/global/cop30_tiles_global_wgs84-height_nunatak.vrt \
    --format GTiff \
    --save-temps \
    /mnt/pgc/data/common/quickbase/2204_UW_Andresen_Alaska_2023/imagery_check/renamed \
    /mnt/pgc/data/common/quickbase/2204_UW_Andresen_Alaska_2023/imagery_check/ortho-16-rf-noDataTest-2 
```

The final images have the NoData value set as `65535` as intended. However, the value of the NoData cells is modified by the stretching process, resulting in each band having a unique cell value in the NoData areas that is not `65535`.