### PR TITLE
Slurm log location option

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -1926,12 +1926,14 @@ def check_image_auto_dem(geometry_wkt, spatial_ref, gpkg_path):
 
         # If there are multiple overlapping layers, choose the one where the image centroid is located
         if len(overlapping_layers) > 1:
-            logger.debug("check overlapping_layers >: %s", len(overlapping_layers))
+            logger.debug("multiple overlapping DEMs: %s. Checking image centroid", len(overlapping_layers))
             for layer in overlapping_layers:
-                feature = layer.GetNextFeature()
-                if feature_geometry is not None:
+                layer.ResetReading()
+                dem_feature = layer.GetNextFeature()
+                dem_feature_geometry = dem_feature.GetGeometryRef()
+                if dem_feature_geometry is not None:
                     try:
-                        if feature_geometry.Contains(image_geometry_transformed.Centroid()):
+                        if dem_feature_geometry.Contains(image_geometry_transformed.Centroid()):
                             selected_layer = layer
                             break  # Exit the loop once the desired layer is found
                     except Exception as e:

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -87,7 +87,8 @@ class SLURMTaskHandler(object):
     def run_tasks(self, tasks):
 
         for task in tasks:
-            cmd = r'sbatch -J {} --export=p1="{} {}" "{}"'.format(
+            cmd = r'sbatch {} -J {} --export=p1="{} {}" "{}"'.format(
+                self.qsub_args,
                 task.abrv,
                 task.exe,
                 escape_problem_jobsubmit_chars(task.cmd),

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -85,10 +85,6 @@ def main():
                         help="submit tasks to PBS")
     parser.add_argument("--slurm", action='store_true', default=False,
                         help="submit tasks to SLURM")
-    parser.add_argument("--slurm-log-dir", default=None,
-                        help="directory path for logs from slurm jobs on the cluster. "
-                             "Default is the parent directory of the mosaic output. "
-                             "To use the current working directory, use 'working_dir'")
     parser.add_argument("--parallel-processes", type=int, default=1,
                         help="number of parallel processes to spawn (default 1)")
     parser.add_argument("--qsubscript",
@@ -124,23 +120,6 @@ def main():
         if not os.path.isfile(qsubpath):
             parser.error("qsub script path is not valid: {}".format(qsubpath))
 
-    # Parse slurm log location
-    if args.slurm:
-        # by default, the parent directory of the dst dir is used for saving slurm logs
-        if args.slurm_log_dir == None:
-            slurm_log_dir = os.path.abspath(os.path.join(mosaic_dir, os.pardir))
-            print("slurm log dir: {}".format(slurm_log_dir))
-        # if "working_dir" is passed in the CLI, use the default slurm behavior which saves logs in working dir
-        elif args.slurm_log_dir == "working_dir":
-            slurm_log_dir = None
-        # otherwise, verify that the path for the logs is a valid path
-        else:
-            slurm_log_dir = os.path.abspath(args.slurm_log_dir)
-        # Verify slurm log path
-        if not os.path.isdir(slurm_log_dir):
-            parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
-        logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
-        
     ## Verify processing options do not conflict
     if args.pbs and args.slurm:
         parser.error("Options --pbs and --slurm are mutually exclusive")
@@ -251,12 +230,8 @@ def main():
                 task_handler.run_tasks(task_queue)
                 
         elif args.slurm:
-            qsub_args = ""
-            if not slurm_log_dir == None:
-                qsub_args += '-o {}/%x.o%j '.format(slurm_log_dir)
-                qsub_args += '-e {}/%x.o%j '.format(slurm_log_dir)
             try:
-                task_handler = taskhandler.SLURMTaskHandler(qsubpath, qsub_args)
+                task_handler = taskhandler.SLURMTaskHandler(qsubpath)
             except RuntimeError as e:
                 logger.error(utils.capture_error_trace())
                 logger.error(e)

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -40,6 +40,10 @@ def main():
                         help="submit tasks to PBS")
     parser.add_argument("--slurm", action='store_true', default=False,
                         help="submit tasks to SLURM")
+    parser.add_argument("--slurm-log-dir", default=None,
+                        help="directory path for logs from slurm jobs on the cluster. "
+                             "Default is the parent directory of the output. "
+                             "To use the current working directory, use 'working_dir'")
     parser.add_argument("--parallel-processes", type=int, default=1,
                         help="number of parallel processes to spawn (default 1)")
     parser.add_argument("--qsubscript",
@@ -85,6 +89,23 @@ def main():
             qsubpath = os.path.abspath(args.qsubscript)
         if not os.path.isfile(qsubpath):
             parser.error("qsub script path is not valid: {}".format(qsubpath))
+
+    # Parse slurm log location
+    if args.slurm:
+        # by default, the parent directory of the dst dir is used for saving slurm logs
+        if args.slurm_log_dir == None:
+            slurm_log_dir = os.path.abspath(os.path.join(dstdir, os.pardir))
+            print("slurm log dir: {}".format(slurm_log_dir))
+        # if "working_dir" is passed in the CLI, use the default slurm behavior which saves logs in working dir
+        elif args.slurm_log_dir == "working_dir":
+            slurm_log_dir = None
+        # otherwise, verify that the path for the logs is a valid path
+        else:
+            slurm_log_dir = os.path.abspath(args.slurm_log_dir)
+        # Verify slurm log path
+        if not os.path.isdir(slurm_log_dir):
+            parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
+        logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
         
     ## Verify processing options do not conflict
     if args.pbs and args.slurm:
@@ -156,8 +177,12 @@ def main():
                     task_handler.run_tasks(task_queue)
                 
         elif args.slurm:
+            qsub_args = ""
+            if not slurm_log_dir == None:
+                qsub_args += '-o {}/%x.o%j '.format(slurm_log_dir)
+                qsub_args += '-e {}/%x.o%j '.format(slurm_log_dir)
             try:
-                task_handler = taskhandler.SLURMTaskHandler(qsubpath)
+                task_handler = taskhandler.SLURMTaskHandler(qsubpath, qsub_args)
             except RuntimeError as e:
                 logger.error(utils.capture_error_trace())
                 logger.error(e)

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -368,34 +368,34 @@ def calc_ndvi(srcfp, dstfp, args):
                 ## generate mask for red nodata, nir nodata, and 
                 ## (red+nir) less than tol away from zero
                 red_mask = (red_array == red_nodata)
-                if red_array[red_mask] != []:
+                if red_array[red_mask].size > 0:
                     nir_mask = (nir_array == nir_nodata)
-                    if nir_array[nir_mask] != []:
+                    if nir_array[nir_mask].size > 0:
                         divzero_mask = abs(nir_array + red_array) < tol
-                        if red_array[divzero_mask] != []:
+                        if red_array[divzero_mask].size > 0:
                             ndvi_mask = red_mask | nir_mask | divzero_mask
                         else:
                             ndvi_mask = red_mask | nir_mask
                     else:
                         divzero_mask = abs(nir_array + red_array) < tol
-                        if red_array[divzero_mask] != []:
+                        if red_array[divzero_mask].size > 0:
                             ndvi_mask = red_mask | divzero_mask
                         else:
                             ndvi_mask = red_mask
                 else:
                     nir_mask = (nir_array == nir_nodata)
-                    if nir_array[nir_mask] != []:
+                    if nir_array[nir_mask].size > 0:
                         divzero_mask = abs(nir_array + red_array) < tol
-                        if red_array[divzero_mask] != []:
+                        if red_array[divzero_mask].size > 0:
                             ndvi_mask = nir_mask | divzero_mask
                         else:
                             ndvi_mask = nir_mask
                     else:
                         divzero_mask = abs(nir_array + red_array) < tol
-                        if red_array[divzero_mask] != []:
+                        if red_array[divzero_mask].size > 0:
                             ndvi_mask = divzero_mask
                         else:
-                            ndvi_mask = numpy.full_like(red_array, fill_value=0, dtype=numpy.bool)
+                            ndvi_mask = numpy.full_like(red_array, fill_value=0, dtype=bool)
 
                 ## declare ndvi array, init to nodata value
                 ndvi_array = numpy.full_like(red_array, fill_value=ndvi_nodata, dtype=numpy.float32)

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -89,6 +89,23 @@ def main():
         if not os.path.isfile(qsubpath):
             parser.error("qsub script path is not valid: {}".format(qsubpath))
 
+    # Parse slurm log location
+    if args.slurm:
+        # by default, the parent directory of the dst dir is used for saving slurm logs
+        if args.slurm_log_dir == None:
+            slurm_log_dir = os.path.abspath(os.path.join(dstdir, os.pardir))
+            print("slurm log dir: {}".format(slurm_log_dir))
+        # if "working_dir" is passed in the CLI, use the default slurm behavior which saves logs in working dir
+        elif args.slurm_log_dir == "working_dir":
+            slurm_log_dir = None
+        # otherwise, verify that the path for the logs is a valid path
+        else:
+            slurm_log_dir = os.path.abspath(args.slurm_log_dir)
+        # Verify slurm log path
+        if not os.path.isdir(slurm_log_dir):
+            parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
+        logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
+
     ## Verify processing options do not conflict
     requested_threads = ortho_functions.ARGDEF_CPUS_AVAIL if args.threads == "ALL_CPUS" else args.threads
     if args.pbs and args.slurm:
@@ -159,7 +176,6 @@ def main():
 
     # write input command to text file next to output folder for reference
     command_str = ' '.join(sys.argv)
-    logger.info("Running command: {}".format(command_str))
     if not args.skip_cmd_txt and not args.dryrun:
         utils.write_input_command_txt(command_str,dstdir)
         args.skip_cmd_txt = True
@@ -407,8 +423,12 @@ def main():
                     task_handler.run_tasks(task_queue, dryrun=args.dryrun)
 
         elif args.slurm:
+            qsub_args = ""
+            if not slurm_log_dir == None:
+                qsub_args += '-o {}/%x.o%j '.format(slurm_log_dir)
+                qsub_args += '-e {}/%x.o%j '.format(slurm_log_dir)
             try:
-                task_handler = taskhandler.SLURMTaskHandler(qsubpath)
+                task_handler = taskhandler.SLURMTaskHandler(qsubpath, qsub_args)
             except RuntimeError as e:
                 logger.error(utils.capture_error_trace())
                 logger.error(e)

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -35,6 +35,10 @@ def main():
                         help="submit tasks to PBS")
     parser.add_argument("--slurm", action='store_true', default=False,
                         help="submit tasks to SLURM")
+    parser.add_argument("--slurm-log-dir", default=None,
+                        help="directory path for logs from slurm jobs on the cluster. "
+                             "Default is the parent directory of the output. "
+                             "To use the current working directory, use 'working_dir'")
     parser.add_argument("--tasks-per-job", type=int,
                         help="Number of tasks to bundle into a single job. (requires --pbs or --slurm option) (Warning:"
                              " a higher number of tasks per job may require modification of default wallclock limit.)")

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -180,6 +180,10 @@ def main():
                         help="submit tasks to PBS")
     parser.add_argument("--slurm", action='store_true', default=False,
                         help="submit tasks to SLURM")
+    parser.add_argument("--slurm-log-dir", default=None,
+                        help="directory path for logs from slurm jobs on the cluster. "
+                             "Default is the parent directory of the output. "
+                             "To use the current working directory, use 'working_dir'")
     parser.add_argument("--tasks-per-job", type=int,
                         help="Number of tasks to bundle into a single job. (requires --pbs or --slurm option) (Warning:"
                              " a higher number of tasks per job may require modification of default wallclock limit.)")
@@ -231,6 +235,23 @@ def main():
             qsubpath = os.path.abspath(args.qsubscript)
         if not os.path.isfile(qsubpath):
             parser.error("qsub script path is not valid: {}".format(qsubpath))
+
+        # Parse slurm log location
+        if args.slurm:
+            # by default, the parent directory of the dst dir is used for saving slurm logs
+            if args.slurm_log_dir == None:
+                slurm_log_dir = os.path.abspath(os.path.join(dstdir, os.pardir))
+                print("slurm log dir: {}".format(slurm_log_dir))
+            # if "working_dir" is passed in the CLI, use the default slurm behavior which saves logs in working dir
+            elif args.slurm_log_dir == "working_dir":
+                slurm_log_dir = None
+            # otherwise, verify that the path for the logs is a valid path
+            else:
+                slurm_log_dir = os.path.abspath(args.slurm_log_dir)
+            # Verify slurm log path
+            if not os.path.isdir(slurm_log_dir):
+                parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
+            logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
 
     ## Verify processing options do not conflict
     requested_threads = ortho_functions.ARGDEF_CPUS_AVAIL if args.threads == "ALL_CPUS" else args.threads
@@ -480,8 +501,12 @@ def main():
                     task_handler.run_tasks(task_queue, dryrun=args.dryrun)
                 
         elif args.slurm:
+            qsub_args = ""
+            if not slurm_log_dir == None:
+                qsub_args += '-o {}/%x.o%j '.format(slurm_log_dir)
+                qsub_args += '-e {}/%x.o%j '.format(slurm_log_dir)
             try:
-                task_handler = taskhandler.SLURMTaskHandler(qsubpath)
+                task_handler = taskhandler.SLURMTaskHandler(qsubpath, qsub_args)
             except RuntimeError as e:
                 logger.error(utils.capture_error_trace())
                 logger.error(e)

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -299,10 +299,12 @@ def main():
     if args.dem is not None and args.ortho_height is not None:
         parser.error("--dem and --ortho_height options are mutually exclusive.  Please choose only one.")
 
+    ## verify auto DEM
+    if args.dem == 'auto':
+        logger.info("DEM is auto default")
     #### Test if DEM exists
-    if args.dem:
-        if not os.path.isfile(args.dem):
-            parser.error("DEM does not exist: {}".format(args.dem))
+    elif args.dem is not None and not os.path.isfile(args.dem):
+        parser.error("DEM does not exist: {}".format(args.dem))
         if args.l is None:
             if args.dem.endswith('.vrt'):
                 total_dem_filesz_gb = 0.0


### PR DESCRIPTION
Adds an option to `pgc_ortho.py`, `pgc_pansharpen.py`, and `pgc_ndvi.py` to set the output location for slurm logs when running operations on the cluster. This changes the default behavior of those scripts from the SLURM default of writing output/err logs in the working directory, instead making the default log output directory the parent directory of the script dst. So if the dst dir is `project/imagery/ortho/` then the log from the cluster gets written to `project/imagery/Or0001.oJOBID`. 

The change has not been applied to `pgc_mosaic.py` yet because that handles logging slightly differently.

This PR also fixes a bug from the AutoDEM PR: https://github.com/PolarGeospatialCenter/imagery_utils/pull/76 and applied a couple small fixes to `pgc_ndvi.py` to address some deprecation warnings for array handling.  