### PR TITLE
add option for passing custom slurm job name

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -631,8 +631,6 @@ def build_parent_argument_parser():
     parser.add_argument("-d", "--dem",
                         help="the DEM to use for orthorectification (elevation values should be relative to the wgs84 "
                              "ellipsoid,  'auto': closest dem overlapping the area")
-
-    # Add the --config-file argument to the main parser
     parser.add_argument("--config-file", help="Location of config file (default={})".format(default_config),
                         default=default_config)
     parser.add_argument("-t", "--outtype", choices=[output_type.value for output_type in OutputType], default=OutputType.BYTE.value,

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -87,21 +87,13 @@ class SLURMTaskHandler(object):
     def run_tasks(self, tasks):
 
         for task in tasks:
-            if "-J" not in self.qsub_args:
-                cmd = r'sbatch {} -J {} --export=p1="{} {}" "{}"'.format(
-                    self.qsub_args,
-                    task.abrv,
-                    task.exe,
-                    escape_problem_jobsubmit_chars(task.cmd),
-                    self.qsubscript
-                )
-            else:
-                cmd = r'sbatch {} --export=p1="{} {}" "{}"'.format(
-                    self.qsub_args,
-                    task.exe,
-                    escape_problem_jobsubmit_chars(task.cmd),
-                    self.qsubscript
-                )
+            cmd = r'sbatch {} -J {} --export=p1="{} {}" "{}"'.format(
+                self.qsub_args,
+                task.abrv,
+                task.exe,
+                escape_problem_jobsubmit_chars(task.cmd),
+                self.qsubscript
+            )
             subprocess.call(cmd, shell=True)
             
 

--- a/lib/taskhandler.py
+++ b/lib/taskhandler.py
@@ -87,13 +87,21 @@ class SLURMTaskHandler(object):
     def run_tasks(self, tasks):
 
         for task in tasks:
-            cmd = r'sbatch {} -J {} --export=p1="{} {}" "{}"'.format(
-                self.qsub_args,
-                task.abrv,
-                task.exe,
-                escape_problem_jobsubmit_chars(task.cmd),
-                self.qsubscript
-            )
+            if "-J" not in self.qsub_args:
+                cmd = r'sbatch {} -J {} --export=p1="{} {}" "{}"'.format(
+                    self.qsub_args,
+                    task.abrv,
+                    task.exe,
+                    escape_problem_jobsubmit_chars(task.cmd),
+                    self.qsubscript
+                )
+            else:
+                cmd = r'sbatch {} --export=p1="{} {}" "{}"'.format(
+                    self.qsub_args,
+                    task.exe,
+                    escape_problem_jobsubmit_chars(task.cmd),
+                    self.qsubscript
+                )
             subprocess.call(cmd, shell=True)
             
 

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -39,6 +39,8 @@ def main():
                         help="directory path for logs from slurm jobs on the cluster. "
                              "Default is the parent directory of the output. "
                              "To use the current working directory, use 'working_dir'")
+    parser.add_argument("--slurm-job-name", default=None,
+                        help="assign a name to the slurm job for easier job tracking")
     parser.add_argument("--tasks-per-job", type=int,
                         help="Number of tasks to bundle into a single job. (requires --pbs or --slurm option) (Warning:"
                              " a higher number of tasks per job may require modification of default wallclock limit.)")

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -424,6 +424,10 @@ def main():
 
         elif args.slurm:
             qsub_args = ""
+            # add a custom name to the slurm job log
+            if args.slurm_job_name:
+                slurm_job_name = str(args.slurm_job_name)
+                qsub_args += '-J {} '.format(slurm_job_name)
             if not slurm_log_dir == None:
                 qsub_args += '-o {}/%x.o%j '.format(slurm_log_dir)
                 qsub_args += '-e {}/%x.o%j '.format(slurm_log_dir)

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -391,9 +391,15 @@ def main():
         else:  # this case occurs when there is a textfile or csv to resubmit so dstfp is not needed
             dstfp = None
 
+        # add a custom name to the job
+        if not args.slurm_job_name:
+            job_name = 'Or{:04g}'.format(job_count)
+        else:
+            job_name = str(args.slurm_job_name)
+
         task = taskhandler.Task(
             srcfn,
-            'Or{:04g}'.format(job_count),
+            job_name,
             'python',
             '{} {} {} {}'.format(
                 argval2str(scriptpath),
@@ -426,10 +432,6 @@ def main():
 
         elif args.slurm:
             qsub_args = ""
-            # add a custom name to the slurm job log
-            if args.slurm_job_name:
-                slurm_job_name = str(args.slurm_job_name)
-                qsub_args += '-J {} '.format(slurm_job_name)
             if not slurm_log_dir == None:
                 qsub_args += '-o {}/%x.o%j '.format(slurm_log_dir)
                 qsub_args += '-e {}/%x.o%j '.format(slurm_log_dir)


### PR DESCRIPTION
Adds cli arg for custom slurm job name to facilitate slurm job tracking in Fridge automated processing. Passing this arg in the command bypasses the default job naming scheme in the `taskhandler`