### PR TITLE
Add slurm queue arg to ortho and pansharpen scripts

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -41,6 +41,10 @@ resamples = ["near", "bilinear", "cubic", "cubicspline", "lanczos"]
 gtiff_compressions = ["jpeg95", "lzw"]
 exts = ['.ntf', '.tif']
 ARGDEF_THREADS = 1
+
+# slurm partitions as of 7/3/2024: update here for acceptable inputs to '--queue' arg if cluster partitions change
+slurm_partitions = ['batch','big_mem','low_priority']
+
 try:
     # Python 3.x only
     ARGDEF_CPUS_AVAIL = os.cpu_count()

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -112,9 +112,10 @@ def main():
         else:
             slurm_log_dir = os.path.abspath(args.slurm_log_dir)
         # check that partition names are valid
-        if not args.queue in ortho_functions.slurm_partitions:
-            parser.error("--queue argument is not a valid slurm partition. "
-                         "Valid partitions: {}".format(ortho_functions.slurm_partitions))
+        if args.queue and not args.queue in ortho_functions.slurm_partitions:
+            parser.error("--queue argument '{}' is not a valid slurm partition. "
+                         "Valid partitions: {}".format(args.queue,
+                                                       ortho_functions.slurm_partitions))
         # Verify slurm log path
         if not os.path.isdir(slurm_log_dir):
             parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -54,7 +54,9 @@ def main():
     parser.add_argument("-l",
                         help="PBS resources requested (mimicks qsub syntax, PBS only)")
     parser.add_argument("--queue",
-                        help="PBS queue to submit jobs to")
+                        help="Cluster queue/partition to submit jobs to. Accepted slurm queues: batch (default "
+                             "partition, no need to specify it in this arg), big_mem (for large memory jobs), "
+                             "and low_priority (for background processes)")
     parser.add_argument("--dryrun", action='store_true', default=False,
                         help='print actions without executing')
     parser.add_argument("-v", "--verbose", action='store_true', default=False,
@@ -109,6 +111,10 @@ def main():
         # otherwise, verify that the path for the logs is a valid path
         else:
             slurm_log_dir = os.path.abspath(args.slurm_log_dir)
+        # check that partition names are valid
+        if not args.queue in ortho_functions.slurm_partitions:
+            parser.error("--queue argument is not a valid slurm partition. "
+                         "Valid partitions: {}".format(ortho_functions.slurm_partitions))
         # Verify slurm log path
         if not os.path.isdir(slurm_log_dir):
             parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
@@ -439,6 +445,8 @@ def main():
             # default wallclock for ortho jobs is 1:00:00, refer to slurm_ortho.sh to verify
             if args.tasks_per_job:
                 qsub_args += '-t {}:00:00 '.format(args.tasks_per_job)
+            if args.queue:
+                qsub_args += "-p {} ".format(args.queue)
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath, qsub_args)
             except RuntimeError as e:

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -199,7 +199,9 @@ def main():
     parser.add_argument("-l",
                         help="PBS resources requested (mimicks qsub syntax, PBS only)")
     parser.add_argument("--queue",
-                        help="PBS queue to submit jobs to")
+                        help="Cluster queue/partition to submit jobs to. Accepted slurm queues: batch (default "
+                             "partition, no need to specify it in this arg), big_mem (for large memory jobs), "
+                             "and low_priority (for background processes)")
     parser.add_argument("--dryrun", action="store_true", default=False,
                         help="print actions without executing")
 
@@ -250,6 +252,10 @@ def main():
             # otherwise, verify that the path for the logs is a valid path
             else:
                 slurm_log_dir = os.path.abspath(args.slurm_log_dir)
+            # check that partition names are valid
+            if not args.queue in ortho_functions.slurm_partitions:
+                parser.error("--queue argument is not a valid slurm partition. "
+                             "Valid partitions: {}".format(ortho_functions.slurm_partitions))
             # Verify slurm log path
             if not os.path.isdir(slurm_log_dir):
                 parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
@@ -528,6 +534,8 @@ def main():
             # default wallclock for pansharpen jobs is 1:00:00, refer to slurm_pansh.sh to verify
             if args.tasks_per_job:
                 qsub_args += '-t {}:00:00 '.format(args.tasks_per_job)
+            if args.queue:
+                qsub_args += "-p {} ".format(args.queue)
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath, qsub_args)
             except RuntimeError as e:

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -253,9 +253,10 @@ def main():
             else:
                 slurm_log_dir = os.path.abspath(args.slurm_log_dir)
             # check that partition names are valid
-            if not args.queue in ortho_functions.slurm_partitions:
-                parser.error("--queue argument is not a valid slurm partition. "
-                             "Valid partitions: {}".format(ortho_functions.slurm_partitions))
+            if args.queue and not args.queue in ortho_functions.slurm_partitions:
+                parser.error("--queue argument '{}' is not a valid slurm partition. "
+                             "Valid partitions: {}".format(args.queue,
+                                                           ortho_functions.slurm_partitions))
             # Verify slurm log path
             if not os.path.isdir(slurm_log_dir):
                 parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))


### PR DESCRIPTION
pgc_ortho and pgc_pansharpen had `--queue` args for specifying PBS queues for processing. This PR adds the same functionality for running jobs on a slurm cluster. If the current cluster partitions (the slurm equivalent of PBS queues) change, update the `slurm_partitions` variable in `lib/ortho_functions.py` to match the slurm cluster configuration.