### PR TITLE
Fix ortho metadata file for IKONOS imagery

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -184,7 +184,7 @@ def get_sensor(srcfn):
 
     if not vendor:
         for pattern in IK_patterns:
-            p = re.compile(pattern)
+            p = re.compile(pattern, re.IGNORECASE)
             m = p.search(srcfn.lower())
             if m is not None:
                 vendor = Vendor.GE


### PR DESCRIPTION
When I try to run pgc_ortho.py on ikonos imagery, the xml file that gets generated does not include the xml from the original image.

Here is one example:

```
<?xml version="1.0" ?>
<IMD>
        <PGC_IMD>
                <VERSION>imagery_utils v2.1.3</VERSION>
                <PROCESS_DATE>10-Jul-2024 23:31:40</PROCESS_DATE>
                <ORTHO_HEIGHT>TanDEMX_PolarDEM_90m.tif</ORTHO_HEIGHT>
                <RESAMPLEMETHOD>near</RESAMPLEMETHOD>
                <STRETCH>rf</STRETCH>
                <BITDEPTH>Byte</BITDEPTH>
                <FORMAT>GTiff</FORMAT>
                <COMPRESSION>lzw</COMPRESSION>
                <EPSG_CODE>3031</EPSG_CODE>
        </PGC_IMD>
        <SOURCE_IMD>
                <SOURCE_IMAGE>IK01_20091214133200_2009121413324560000011614341_po_389987_msi_0000000.ntf</SOURCE_IMAGE>
                <VENDOR>GeoEye</VENDOR>
        </SOURCE_IMD>
</IMD>
```

The xml from the original image should be under `IMD/SOURCE_IMD/IMD`

I found that the match performed [here](https://github.com/PolarGeospatialCenter/imagery_utils/blob/675f66707fbcbe8dfc14a24e93004fe17a3b9c64/lib/ortho_functions.py#L1587) fails, and this is due to this [regex](https://github.com/PolarGeospatialCenter/imagery_utils/blob/675f66707fbcbe8dfc14a24e93004fe17a3b9c64/lib/utils.py#L127) not matching the filename `IK01_20091214133200_2009121413324560000011614341_po_389987_msi_0000000.ntf` since the sensor part of the filename is uppercase. 

I resolved the issue by updating the regex so that it is case insensitive. 
