### PR TITLE
Remove default cmd txt behavior 

### DIFF
--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -676,8 +676,10 @@ def build_parent_argument_parser():
                              '--pbs/--slurm will only accept 1 thread.'
                         .format(ARGDEF_THREADS, ARGDEF_CPUS_AVAIL),
                         default=ARGDEF_THREADS)
-    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
-                        help='Skip writing the txt file containing the input command.')
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=True,
+                        help='THIS OPTION IS DEPRECATED - '
+                             'By default this arg is True and the cmd text file will not be written. '
+                             'Input commands are written to the log for reference.')
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
 
     return parser, pos_arg_keys

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -991,14 +991,3 @@ def subset_vrt_dem(csv_arg_data, csv_header_argname_list, script_args):
 
     return csv_arg_data_trimmed
 
-def write_input_command_txt(arg_str, dst_dir):
-    logger.info("Processing command: {}".format(arg_str))
-    now = datetime.now()
-    base_cmd = os.path.splitext(os.path.basename(arg_str.split()[0]))[0]
-    txt_fn = "{}_command_{}.txt".format(base_cmd, now.strftime("%Y%m%d_%H%M%S"))
-    txt_fp = os.path.join(os.path.abspath(os.path.join(dst_dir, os.pardir)),txt_fn)
-    try:
-        with open(txt_fp, 'w') as f:
-            f.write(arg_str)
-    except:
-        logger.error("Could not write command reference text file")

--- a/pgc_mosaic.py
+++ b/pgc_mosaic.py
@@ -98,8 +98,10 @@ def main():
                         help="PBS resources requested (mimicks qsub syntax). Use only on HPC systems.")
     parser.add_argument("--log",
                         help="file to log progress (default is <output dir>\{}".format(default_logfile))
-    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
-                        help='Skip writing the txt file containing the input command.')
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=True,
+                        help='THIS OPTION IS DEPRECATED - '
+                             'By default this arg is True and the cmd text file will not be written. '
+                             'Input commands are written to the log for reference.')
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
 
     
@@ -181,12 +183,9 @@ def main():
                          "year (e.g., 2017), eight digits and dash for range (e.g., 2015-2017)".format(args.tyear))
             sys.exit(1)
 
-    # write input command to text file next to output folder for reference
+    # log input command for reference
     command_str = ' '.join(sys.argv)
     logger.info("Running command: {}".format(command_str))
-    if not args.skip_cmd_txt:
-        utils.write_input_command_txt(command_str,mosaic_dir)
-        args.skip_cmd_txt = True
 
     #### Check exclude list if specified
     try:

--- a/pgc_mosaic_build_tile.py
+++ b/pgc_mosaic_build_tile.py
@@ -51,7 +51,9 @@ def main():
     parser.add_argument("--gtiff-compression", choices=mosaic.GTIFF_COMPRESSIONS, default="lzw",
                         help="GTiff compression type. Default=lzw ({})".format(','.join(mosaic.GTIFF_COMPRESSIONS)))
     parser.add_argument("--skip-cmd-txt", action='store_true', default=True,
-                        help='Skip writing the txt file containing the input command.')
+                        help='THIS OPTION IS DEPRECATED - '
+                             'By default this arg is True and the cmd text file will not be written. '
+                             'Input commands are written to the log for reference.')
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
 
     
@@ -84,12 +86,9 @@ def main():
     else:
         localpath = os.path.dirname(tile)
 
-    #### write input command to text file next to output folder for reference
+    #### log input command for reference
     command_str = ' '.join(sys.argv)
     logger.info("Running command: {}".format(command_str))
-    if not args.skip_cmd_txt:
-        utils.write_input_command_txt(command_str,localpath)
-        args.skip_cmd_txt = True
     
     intersects = []
     

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -140,10 +140,6 @@ def main():
                          "year (e.g., 2017), eight digits and dash for range (e.g., 2015-2017)".format(args.tyear))
             sys.exit(1)
 
-    # log input command for reference
-    command_str = ' '.join(sys.argv)
-    logger.info("Running command: {}".format(command_str))
-
     ##### Configure Logger
     if args.log is not None:
         logfile = os.path.abspath(args.log)
@@ -160,7 +156,11 @@ def main():
     lsh.setLevel(logging.INFO)
     lsh.setFormatter(formatter)
     logger.addHandler(lsh)
-    
+
+    # log input command for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+
     #### Get exclude_list if specified
     exclude_list = mosaic.getExcludeList(args.exclude)
 

--- a/pgc_mosaic_query_index.py
+++ b/pgc_mosaic_query_index.py
@@ -70,8 +70,10 @@ def main():
                         help="build shapefile of intersecting images (only invoked if --no_sort is not used)")
     parser.add_argument("--require-pan", action='store_true', default=False,
                         help="limit search to imagery with both a multispectral and a panchromatic component")
-    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
-                        help='Skip writing the txt file containing the input command.')
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=True,
+                        help='THIS OPTION IS DEPRECATED - '
+                             'By default this arg is True and the cmd text file will not be written. '
+                             'Input commands are written to the log for reference.')
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
 
  
@@ -138,12 +140,9 @@ def main():
                          "year (e.g., 2017), eight digits and dash for range (e.g., 2015-2017)".format(args.tyear))
             sys.exit(1)
 
-    # write input command to text file next to output folder for reference
+    # log input command for reference
     command_str = ' '.join(sys.argv)
     logger.info("Running command: {}".format(command_str))
-    if not args.skip_cmd_txt:
-        utils.write_input_command_txt(command_str,dstdir)
-        args.skip_cmd_txt = True
 
     ##### Configure Logger
     if args.log is not None:

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -52,8 +52,10 @@ def main():
                         help="submission script to use in PBS/SLURM submission (PBS default is qsub_ndvi.sh, SLURM "
                              "default is slurm_ndvi.py, in script root folder)")
     parser.add_argument("-l", help="PBS resources requested (mimicks qsub syntax, PBS only)")
-    parser.add_argument("--skip-cmd-txt", action='store_true', default=False,
-                        help='Skip writing the txt file containing the input command.')
+    parser.add_argument("--skip-cmd-txt", action='store_true', default=True,
+                        help='THIS OPTION IS DEPRECATED - '
+                             'By default this arg is True and the cmd text file will not be written. '
+                             'Input commands are written to the log for reference.')
     parser.add_argument("--dryrun", action="store_true", default=False,
                         help="print actions without executing")
     parser.add_argument("--version", action='version', version="imagery_utils v{}".format(VERSION))
@@ -115,12 +117,9 @@ def main():
     if (args.pbs or args.slurm) and args.parallel_processes > 1:
         parser.error("HPC Options (--pbs or --slurm) and --parallel-processes > 1 are mutually exclusive")
 
-    # write input command to text file next to output folder for reference
+    # log input command for reference
     command_str = ' '.join(sys.argv)
     logger.info("Running command: {}".format(command_str))
-    if not args.skip_cmd_txt and not args.dryrun:
-        utils.write_input_command_txt(command_str,dstdir)
-        args.skip_cmd_txt = True
 
     #### Set concole logging handler
     lso = logging.StreamHandler()

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -54,7 +54,9 @@ def main():
                              "default is slurm_ndvi.py, in script root folder)")
     parser.add_argument("-l", help="PBS resources requested (mimicks qsub syntax, PBS only)")
     parser.add_argument("--log", nargs='?', const="default",
-                        help="path to file to log progress (default is ortho_<timestamp>.log next to the <dst dir>")
+                        help="output log file -- top level log is not written without this arg. "
+                             "when this flag is used, log will be written to ndvi_<timestamp>.log next to the <dst dir>) "
+                             "unless a specific file path is provided here")
     parser.add_argument("--skip-cmd-txt", action='store_true', default=True,
                         help='THIS OPTION IS DEPRECATED - '
                              'By default this arg is True and the cmd text file will not be written. '

--- a/pgc_ndvi.py
+++ b/pgc_ndvi.py
@@ -99,7 +99,6 @@ def main():
         # by default, the parent directory of the dst dir is used for saving slurm logs
         if args.slurm_log_dir == None:
             slurm_log_dir = os.path.abspath(os.path.join(dstdir, os.pardir))
-            print("slurm log dir: {}".format(slurm_log_dir))
         # if "working_dir" is passed in the CLI, use the default slurm behavior which saves logs in working dir
         elif args.slurm_log_dir == "working_dir":
             slurm_log_dir = None
@@ -109,7 +108,6 @@ def main():
         # Verify slurm log path
         if not os.path.isdir(slurm_log_dir):
             parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
-        logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
         
     ## Verify processing options do not conflict
     if args.pbs and args.slurm:
@@ -117,16 +115,19 @@ def main():
     if (args.pbs or args.slurm) and args.parallel_processes > 1:
         parser.error("HPC Options (--pbs or --slurm) and --parallel-processes > 1 are mutually exclusive")
 
-    # log input command for reference
-    command_str = ' '.join(sys.argv)
-    logger.info("Running command: {}".format(command_str))
-
     #### Set concole logging handler
     lso = logging.StreamHandler()
     lso.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
     lso.setFormatter(formatter)
     logger.addHandler(lso)
+
+    # log input command for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+
+    if args.slurm:
+        logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
 
     #### Get args ready to pass to task handler
     arg_keys_to_remove = ('l', 'qsubscript', 'pbs', 'slurm', 'parallel_processes', 'dryrun')

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -59,7 +59,9 @@ def main():
                              "partition, no need to specify it in this arg), big_mem (for large memory jobs), "
                              "and low_priority (for background processes)")
     parser.add_argument("--log", nargs='?', const="default",
-                        help="path to file to log progress (default is ortho_<timestamp>.log next to the <dst dir>")
+                        help="output log file -- top level log is not written without this arg. "
+                             "when this flag is used, log will be written to ortho_<timestamp>.log next to the <dst dir>) "
+                             "unless a specific file path is provided here")
     parser.add_argument("--dryrun", action='store_true', default=False,
                         help='print actions without executing')
     parser.add_argument("-v", "--verbose", action='store_true', default=False,

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -87,9 +87,6 @@ def main():
     if not os.path.isdir(dstdir):
         parser.error("Error arg2 is not a valid file path: {}".format(dstdir))
 
-    # log input command for reference
-    command_str = ' '.join(sys.argv)
-    logger.info("Running command: {}".format(command_str))
 
     ## Verify qsubscript
     if args.pbs or args.slurm:
@@ -108,7 +105,6 @@ def main():
         # by default, the parent directory of the dst dir is used for saving slurm logs
         if args.slurm_log_dir == None:
             slurm_log_dir = os.path.abspath(os.path.join(dstdir, os.pardir))
-            logger.info("slurm log dir: {}".format(slurm_log_dir))
         # if "working_dir" is passed in the CLI, use the default slurm behavior which saves logs in working dir
         elif args.slurm_log_dir == "working_dir":
             slurm_log_dir = None
@@ -123,7 +119,6 @@ def main():
         # Verify slurm log path
         if not os.path.isdir(slurm_log_dir):
             parser.error("Error directory for slurm logs is not a valid file path: {}".format(slurm_log_dir))
-        logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
 
     ## Verify processing options do not conflict
     requested_threads = ortho_functions.ARGDEF_CPUS_AVAIL if args.threads == "ALL_CPUS" else args.threads
@@ -173,12 +168,10 @@ def main():
     if args.dem is not None and args.ortho_height is not None:
         parser.error("--dem and --ortho_height options are mutually exclusive.  Please choose only one.")
 
-    ## verify auto DEM
-    if args.dem == 'auto':
-        logger.info("DEM is auto default")
     #### Test if DEM exists
-    elif args.dem is not None and not os.path.isfile(args.dem):
-        parser.error("DEM does not exist: {}".format(args.dem))
+    if not args.dem == "auto":
+        if args.dem is not None and not os.path.isfile(args.dem):
+            parser.error("DEM does not exist: {}".format(args.dem))
 
     #### Set up console logging handler
     if args.verbose:
@@ -190,6 +183,13 @@ def main():
     formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s', '%m-%d-%Y %H:%M:%S')
     lso.setFormatter(formatter)
     logger.addHandler(lso)
+
+    # log input command for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+
+    if args.slurm:
+        logger.info("Slurm output and error log saved here: {}".format(slurm_log_dir))
 
     #### Handle thread count that exceeds system limits
     if requested_threads > ortho_functions.ARGDEF_CPUS_AVAIL:

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -87,6 +87,10 @@ def main():
     if not os.path.isdir(dstdir):
         parser.error("Error arg2 is not a valid file path: {}".format(dstdir))
 
+    # log input command for reference
+    command_str = ' '.join(sys.argv)
+    logger.info("Running command: {}".format(command_str))
+
     ## Verify qsubscript
     if args.pbs or args.slurm:
         if args.qsubscript is None:
@@ -104,7 +108,7 @@ def main():
         # by default, the parent directory of the dst dir is used for saving slurm logs
         if args.slurm_log_dir == None:
             slurm_log_dir = os.path.abspath(os.path.join(dstdir, os.pardir))
-            print("slurm log dir: {}".format(slurm_log_dir))
+            logger.info("slurm log dir: {}".format(slurm_log_dir))
         # if "working_dir" is passed in the CLI, use the default slurm behavior which saves logs in working dir
         elif args.slurm_log_dir == "working_dir":
             slurm_log_dir = None
@@ -192,12 +196,6 @@ def main():
         logger.info("threads requested ({0}) exceeds number available on system ({1}), setting thread count to "
                     "'ALL_CPUS'".format(requested_threads, ortho_functions.ARGDEF_CPUS_AVAIL))
         args.threads = 'ALL_CPUS'
-
-    # write input command to text file next to output folder for reference
-    command_str = ' '.join(sys.argv)
-    if not args.skip_cmd_txt and not args.dryrun:
-        utils.write_input_command_txt(command_str,dstdir)
-        args.skip_cmd_txt = True
 
     #### Get args ready to pass to task handler
     arg_keys_to_remove = ('l', 'queue', 'qsubscript', 'dryrun', 'pbs', 'slurm', 'parallel_processes', 'tasks_per_job')

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -203,7 +203,9 @@ def main():
                              "partition, no need to specify it in this arg), big_mem (for large memory jobs), "
                              "and low_priority (for background processes)")
     parser.add_argument("--log", nargs='?', const="default",
-                        help="path to file to log progress (default is ortho_<timestamp>.log next to the <dst dir>")
+                        help="output log file -- top level log is not written without this arg. "
+                             "when this flag is used, log will be written to pansharpen_<timestamp>.log next to the <dst dir>) "
+                             "unless a specific file path is provided here")
     parser.add_argument("--dryrun", action="store_true", default=False,
                         help="print actions without executing")
 

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -352,12 +352,9 @@ def main():
                     "'ALL_CPUS'".format(requested_threads, ortho_functions.ARGDEF_CPUS_AVAIL))
         args.threads = 'ALL_CPUS'
 
-    # write input command to text file next to output folder for reference
+    # log input command for reference
     command_str = ' '.join(sys.argv)
     logger.info("Running command: {}".format(command_str))
-    if not args.skip_cmd_txt and not args.dryrun:
-        utils.write_input_command_txt(command_str,dstdir)
-        args.skip_cmd_txt = True
 
     #### Get args ready to pass to task handler
     arg_keys_to_remove = ('l', 'queue', 'qsubscript', 'dryrun', 'pbs', 'slurm', 'parallel_processes', 'tasks_per_job')

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -312,22 +312,23 @@ def main():
             parser.error("DEM does not exist: {}".format(args.dem))
 
     #### check memory requirements for pbs when using VRT reference dem
-    if args.l is None:
-        if args.dem.endswith('.vrt'):
-            total_dem_filesz_gb = 0.0
-            tree = ET.parse(args.dem)
-            root = tree.getroot()
-            for sourceFilename in root.iter('SourceFilename'):
-                dem_filename = sourceFilename.text
-                if not os.path.isfile(dem_filename):
-                    parser.error("VRT DEM component raster does not exist: {}".format(dem_filename))
-                dem_filesz_gb = os.path.getsize(dem_filename) / 1024.0 / 1024 / 1024
-                total_dem_filesz_gb += dem_filesz_gb
-            dem_filesz_gb = total_dem_filesz_gb
-        else:
-            dem_filesz_gb = os.path.getsize(args.dem) / 1024.0 / 1024 / 1024
-        pbs_req_mem_gb = int(min(50, max(8, math.ceil(dem_filesz_gb) + 2)))
-        args.l = 'mem={}gb'.format(pbs_req_mem_gb)
+    if args.pbs:
+        if args.l is None:
+            if args.dem.endswith('.vrt'):
+                total_dem_filesz_gb = 0.0
+                tree = ET.parse(args.dem)
+                root = tree.getroot()
+                for sourceFilename in root.iter('SourceFilename'):
+                    dem_filename = sourceFilename.text
+                    if not os.path.isfile(dem_filename):
+                        parser.error("VRT DEM component raster does not exist: {}".format(dem_filename))
+                    dem_filesz_gb = os.path.getsize(dem_filename) / 1024.0 / 1024 / 1024
+                    total_dem_filesz_gb += dem_filesz_gb
+                dem_filesz_gb = total_dem_filesz_gb
+            else:
+                dem_filesz_gb = os.path.getsize(args.dem) / 1024.0 / 1024 / 1024
+            pbs_req_mem_gb = int(min(50, max(8, math.ceil(dem_filesz_gb) + 2)))
+            args.l = 'mem={}gb'.format(pbs_req_mem_gb)
         
     ## Check GDAL version (2.1.0 minimum)
     gdal_version = gdal.VersionInfo()

--- a/tests/func_test_ortho.py
+++ b/tests/func_test_ortho.py
@@ -65,7 +65,7 @@ class TestOrthoFunc(unittest.TestCase):
             dstfp = os.path.join(self.dstdir, '{}_u08rf{}.tif'.format(
                 os.path.splitext(test_image)[0], epsg))
             print(srcfp)
-            cmd = r"""python "{}" -r 10 -p {} "{}" "{}" --skip-cmd-txt""".format(
+            cmd = r"""python "{}" -r 10 -p {} "{}" "{}" """.format(
                 self.scriptpath, epsg, srcfp, self.dstdir)
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             se, so = p.communicate()
@@ -84,7 +84,7 @@ class TestOrthoFunc(unittest.TestCase):
             # gtiff compression: jpeg95
             # dem: gimpdem_v2_30m.tif
             ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.ntf',
-             f'-r 10 --skip-cmd-txt --epsg 3413 --stretch mr --resample cubic --format GTiff --outtype Byte --gtiff-compression jpeg95 --dem {self.gimpdem}',
+             f'-r 10 --epsg 3413 --stretch mr --resample cubic --format GTiff --outtype Byte --gtiff-compression jpeg95 --dem {self.gimpdem}',
              True,
              '.tif'),
 
@@ -94,7 +94,7 @@ class TestOrthoFunc(unittest.TestCase):
             # outtype: Byte
             # gtiff compression: jpeg95
             ('GE01_20110108171314_1016023_5V110108M0010160234A222000100252M_000500940.ntf',
-             '-r 10 --skip-cmd-txt --epsg 3413 --stretch mr --rgb --format GTiff --outtype Byte --gtiff-compression jpeg95',
+             '-r 10 --epsg 3413 --stretch mr --rgb --format GTiff --outtype Byte --gtiff-compression jpeg95',
              True,
              '.tif'),
 
@@ -104,7 +104,7 @@ class TestOrthoFunc(unittest.TestCase):
             # outtype: Byte
             # gtiff compression: jpeg95
             ('WV03_20190114103353_104C0100462B2500_19JAN14103353-C1BA-502817502010_01_P001.ntf',
-             '-r 10 --skip-cmd-txt --epsg auto --stretch ns --rgb --format GTiff --outtype Byte --gtiff-compression jpeg95',
+             '-r 10 --epsg auto --stretch ns --rgb --format GTiff --outtype Byte --gtiff-compression jpeg95',
              True,
              '.tif'),
 
@@ -112,7 +112,7 @@ class TestOrthoFunc(unittest.TestCase):
             # epsg: 3413
             # stretch: auto
             ('WV03_20150712212305_104A01000E7C1F00_15JUL12212305-A1BS-500802261010_01_P001.ntf',
-             '-r 10 --skip-cmd-txt --epsg 3413 --stretch au --rgb --format GTiff --outtype Byte --gtiff-compression jpeg95',
+             '-r 10 --epsg 3413 --stretch au --rgb --format GTiff --outtype Byte --gtiff-compression jpeg95',
              True,
              '.tif'),
 
@@ -124,7 +124,7 @@ class TestOrthoFunc(unittest.TestCase):
             # gtiff compression: lzw
             # dem: gimpdem_v2_30m.tif
             ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.ntf',
-             f'-r 10 --skip-cmd-txt --epsg 3413 --stretch rf --resample near --format ENVI --outtype Byte --gtiff-compression lzw --dem {self.gimpdem}',
+             f'-r 10 --epsg 3413 --stretch rf --resample near --format ENVI --outtype Byte --gtiff-compression lzw --dem {self.gimpdem}',
              True,
              '.envi'),
 
@@ -136,7 +136,7 @@ class TestOrthoFunc(unittest.TestCase):
             # gtiff compression: lzw
             # dem: Y:/private/elevation/dem/GIMP/GIMPv2/gimpdem_v2_30m.tif
             ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.ntf',
-             f'-r 10 --skip-cmd-txt --epsg 3413 --stretch rf --resample near --format HFA --outtype Float32 --gtiff-compression lzw --dem {self.gimpdem}',
+             f'-r 10 --epsg 3413 --stretch rf --resample near --format HFA --outtype Float32 --gtiff-compression lzw --dem {self.gimpdem}',
              True,
              '.img'),
 
@@ -145,14 +145,14 @@ class TestOrthoFunc(unittest.TestCase):
             # outtype: UInt16
             # format: .jp2
             ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.ntf',
-             '-r 10 --skip-cmd-txt --epsg 3413 --stretch rd --resample near --format JP2OpenJPEG --outtype UInt16 --gtiff-compression lzw',
+             '-r 10 --epsg 3413 --stretch rd --resample near --format JP2OpenJPEG --outtype UInt16 --gtiff-compression lzw',
              True,
              '.jp2'),
 
             # dem: Y:/private/elevation/dem/RAMP/RAMPv2/ RAMPv2_wgs84_200m.tif
             # should fail: the image is not contained within the DEM
             ('QB02_20120827132242_10100100101AD000_12AUG27132242-M1BS-500122876080_01_P006.ntf',
-             f'-r 10 --skip-cmd-txt --epsg 3413 --dem {self.rampdem}',
+             f'-r 10 --epsg 3413 --dem {self.rampdem}',
              False,
              '.tif'),
         ]


### PR DESCRIPTION
This PR removes the default behavior for writing the input command to a txt file next to the output location and deprecates the `--skip-cmd-txt` arg, leaving it as a dummy arg but removing the functionality. References to the argument have been removed outside of the CLI arg parser. Input commands are written to the top of the log for each of the processing scripts in the repo. 