### PR TITLE
Remove PBS dynamic memory parameter calculation

### DIFF
--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -291,25 +291,6 @@ def main():
     else:
         image_list1 = [src]
 
-    ## Automatically set PBS job requested memory if applicable
-    if (    args.dem is not None and args.pbs and args.l is None
-        and (srctype != 'csvfile' or 'dem' not in csv_header_argname_list)):
-        if args.dem.endswith('.vrt'):
-            total_dem_filesz_gb = 0.0
-            tree = ET.parse(args.dem)
-            root = tree.getroot()
-            for sourceFilename in root.iter('SourceFilename'):
-                dem_filename = sourceFilename.text
-                if not os.path.isfile(dem_filename):
-                    parser.error("VRT DEM component raster does not exist: {}".format(dem_filename))
-                dem_filesz_gb = os.path.getsize(dem_filename) / 1024.0 / 1024 / 1024
-                total_dem_filesz_gb += dem_filesz_gb
-            dem_filesz_gb = total_dem_filesz_gb
-        else:
-            dem_filesz_gb = os.path.getsize(args.dem) / 1024.0 / 1024 / 1024
-        pbs_req_mem_gb = int(min(50, max(8, math.ceil(dem_filesz_gb) + 2)))
-        args.l = 'mem={}gb'.format(pbs_req_mem_gb)
-
     ## Group Ikonos
     image_list2 = []
     for i, srcfp in enumerate(image_list1):

--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -315,25 +315,6 @@ def main():
     if not args.dem == 'auto':
         if args.dem is not None and not os.path.isfile(args.dem):
             parser.error("DEM does not exist: {}".format(args.dem))
-
-    #### check memory requirements for pbs when using VRT reference dem
-    if args.pbs:
-        if args.l is None:
-            if args.dem.endswith('.vrt'):
-                total_dem_filesz_gb = 0.0
-                tree = ET.parse(args.dem)
-                root = tree.getroot()
-                for sourceFilename in root.iter('SourceFilename'):
-                    dem_filename = sourceFilename.text
-                    if not os.path.isfile(dem_filename):
-                        parser.error("VRT DEM component raster does not exist: {}".format(dem_filename))
-                    dem_filesz_gb = os.path.getsize(dem_filename) / 1024.0 / 1024 / 1024
-                    total_dem_filesz_gb += dem_filesz_gb
-                dem_filesz_gb = total_dem_filesz_gb
-            else:
-                dem_filesz_gb = os.path.getsize(args.dem) / 1024.0 / 1024 / 1024
-            pbs_req_mem_gb = int(min(50, max(8, math.ceil(dem_filesz_gb) + 2)))
-            args.l = 'mem={}gb'.format(pbs_req_mem_gb)
         
     ## Check GDAL version (2.1.0 minimum)
     gdal_version = gdal.VersionInfo()


### PR DESCRIPTION
This PR removes a section that dynamically sets the PBS per-job memory based on the size of the input VRT DEM for orthorectification.  This setting is not necessary and is somewhat dangerous/confusing, so we decided to drop it instead of making it apply to SLURM.