### PR TITLE
Auto DEM Bug Repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ reference of EPSG 3031, or Antarctic Polar Stereographic -71.
 
 #### DEM Auto-Selection Configuration (when using `--dem auto`)
 
-When using the `--dem auto` setting in `pgc_ortho.py`, the script will automatically attempt to select an appropriate DEM based on image location and geometry. For this to work, a configuration file must be specified using the `--config` option. This configuration file should contain a valid `gpkg_path` entry, which points to the GeoPackage file that holds DEM coverage information.
+When using the `--dem auto` setting in `pgc_ortho.py`, the script will automatically attempt to select an appropriate 
+DEM based on image location and geometry. For this to work, a configuration file must be specified using the `--config`
+option. This configuration file should contain a valid `gpkg_path` entry, which points to the GeoPackage file that holds
+DEM coverage information.
 
 **Configuration Requirements**
 
-The config file should point to a file path for checking image overlap with reference dems. This path should locate a geopackage file which includes geometries of a list of reference DEMs.
-Each feature in each layer of the geopackage file should have a field named 'dempath' pointing to the corresponding reference DEM
+The config file should point to a file path for checking image overlap with reference dems. This path should locate a 
+geopackage file which includes geometries of a list of reference DEMs. Each feature in each layer of the geopackage 
+should have a field named 'dempath' pointing to the corresponding reference DEM.
 
 1. **Config File Path**: Ensure that the config file exists at the specified path provided to the `--config` argument.
-2. **`gpkg_path` Setting**: The config file should have a `gpkg_path` entry under the `[default]` section. This path should point to a GeoPackage file containing a 'dempath' field to the corresponding DEM.
+2. **`gpkg_path` Setting**: The config file should have a `gpkg_path` entry under the `[default]` section. This path 
+should point to a GeoPackage file containing a 'dempath' field to the corresponding DEM.
 3. **Valid DEM File**: The path specified by `dempath` should be accessible and valid.
 
 **Example Configuration File (`config.ini`)**
@@ -148,9 +153,7 @@ On Linux systems:
 ```sh
 # first time only
 ln -s <test_data_location>/tests/testdata tests/
-```
 
-```sh
 # run the test
 pytest tests
 ```


### PR DESCRIPTION
Problem: the Auto DEM selection code would abort the script if no overlapping DEM was found, assuming it was an error.  But, having no auto-selected DEM is a reasonable use case, so the script needs to be able to fail-through to running without a DEM.

Solution: I reorganized the DEM selection code to raise a Runtime Exception on error and return None if no overlapping DEM was found.  I added tests to catch test the error handling and correct fail-though behavior.
