### PR TITLE
replace exception for running query without required mosaic args

### DIFF
--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -832,11 +832,15 @@ def filter_images_by_geometry(imginfo_list, params):
 def getMosaicParameters(iinfo, options):
     
     params = MosaicParams()
-    
-    if options.resolution is not None:
-        params.xres = options.resolution[0]
-        params.yres = options.resolution[1]
-    else:
+
+    try:
+        if options.resolution is not None:
+            params.xres = options.resolution[0]
+            params.yres = options.resolution[1]
+        else:
+            params.xres = iinfo.xres
+            params.yres = iinfo.yres
+    except AttributeError:
         params.xres = iinfo.xres
         params.yres = iinfo.yres
 
@@ -872,13 +876,20 @@ def getMosaicParameters(iinfo, options):
                                                                             params.xmax, params.ymin, params.xmin,
                                                                             params.ymin)
         params.extent_geom = ogr.CreateGeometryFromWkt(poly_wkt)
-    
-    if options.tilesize is not None:
-        params.xtilesize = options.tilesize[0]
-        params.ytilesize = options.tilesize[1]
-    else:
-        params.xtilesize = params.xres * 40000
-        params.ytilesize = params.yres * 40000
+
+    try:
+        if options.tilesize is not None:
+            params.xtilesize = options.tilesize[0]
+            params.ytilesize = options.tilesize[1]
+
+    except AttributeError:
+        if params.xres is not None:
+            params.xtilesize = params.xres * 40000
+            params.ytilesize = params.yres * 40000
+        else:
+            params.xtilesize = None
+            params.ytilesize = None
+
 
     if options.max_cc is not None:
         params.max_cc = options.max_cc
@@ -888,8 +899,11 @@ def getMosaicParameters(iinfo, options):
     params.force_pan_to_multi = True if params.bands > 1 and options.force_pan_to_multi else False # determine if force pan to multi is applicable and true
 
     params.include_all_ms = options.include_all_ms
-    
-    params.median_remove = options.median_remove
+
+    try:
+        params.median_remove = options.median_remove
+    except AttributeError:
+        params.median_remove = None
 
     return params
 


### PR DESCRIPTION
Removed some try except clauses for attribute errors in a previous PR that are actually necessary. When running `pgc_mosaic_query_index.py`, there are some args that are not included in the CLI because they are not necessary, but the `pgc_mosaic.py` references the same `getMosaicParams()` function and expects those args. This replaces the functionality to handle the different usages of the function. 