### PR TITLE
Pansh weight bug fix

### DIFF
--- a/pgc_pansharpen.py
+++ b/pgc_pansharpen.py
@@ -722,7 +722,7 @@ def exec_pansharpen(image_pair, pansh_dstfp, args, orig_res):
     weight_args = ''
     if not args.skip_custom_weights:
         # add specific pansharpening weights for WV02 and WV03 images - get band count of input mul from image info
-        iinfo = ortho_functions.ImageInfo(image_pair.mul_srcfp, mul_dstfp, wd, args)
+        iinfo = ortho_functions.ImageInfo(mul_dstfp, dstdir, wd, args)
         _err = iinfo.get_image_stats(args)
         if _err != 0:
             raise RuntimeError(f"Error in stats calculation")

--- a/tests/test_pansharpen.py
+++ b/tests/test_pansharpen.py
@@ -103,8 +103,8 @@ class TestPanshFunc(unittest.TestCase):
                             f'found:{image_info.datapixelcount_dct[i]}, expected {datapixelcount_dct[i]} +-{datapixelcount_threshold/100} percent')
 
     def test_pansharpen_cog(self):
-        src = self.srcdir
-        cmd = 'python {} {} {} --skip-cmd-txt -p 3413 -f COG'.format(
+        src = os.path.join(self.srcdir, "WV02_20110901210502_103001000D52C800_11SEP01210502-M1BS-052560788010_01_P008.ntf")
+        cmd = 'python {} {} {} --skip-cmd-txt -p 3413 -r 10 -f COG'.format(
             self.scriptpath,
             src,
             self.dstdircog,
@@ -120,13 +120,6 @@ class TestPanshFunc(unittest.TestCase):
 
         self.assertTrue(os.path.isfile(dstfp))
         self.assertTrue(os.path.isfile(dstfp_xml))
-
-        # check second image from proccessing
-        dstfp_2 = os.path.join(self.dstdircog, 'WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u08rf3413_pansh.tif')
-        dstfp_xml_2 = os.path.join(self.dstdircog, 'WV02_20110901210434_103001000B41DC00_11SEP01210434-M1BS-052730735130_01_P007_u08rf3413_pansh.xml')
-
-        self.assertTrue(os.path.isfile(dstfp_2))
-        self.assertTrue(os.path.isfile(dstfp_xml_2))
 
         with gdal.Open(dstfp, gdalconst.GA_ReadOnly) as ds:
             self.assertIn('LAYOUT=COG', ds.GetMetadata_List('IMAGE_STRUCTURE'))

--- a/tests/test_pansharpen.py
+++ b/tests/test_pansharpen.py
@@ -23,6 +23,9 @@ class TestPanshFunc(unittest.TestCase):
         self.dstdircog = os.path.join(__test_dir__, 'tmp_output_cog')
         if not os.path.isdir(self.dstdircog):
             os.makedirs(self.dstdircog)
+        self.dstdirrgb = os.path.join(__test_dir__, 'tmp_output_rgb')
+        if not os.path.isdir(self.dstdirrgb):
+            os.makedirs(self.dstdirrgb)
 
     def test_pansharpen(self):
 
@@ -127,6 +130,28 @@ class TestPanshFunc(unittest.TestCase):
 
         with gdal.Open(dstfp, gdalconst.GA_ReadOnly) as ds:
             self.assertIn('LAYOUT=COG', ds.GetMetadata_List('IMAGE_STRUCTURE'))
+
+    def test_pansharpen_rgb(self):
+        src = os.path.join(self.srcdir, "WV02_20110901210502_103001000D52C800_11SEP01210502-M1BS-052560788010_01_P008.ntf")
+        cmd = 'python {} {} {} --skip-cmd-txt -p 3413 -r 10 --rgb'.format(
+            self.scriptpath,
+            src,
+            self.dstdirrgb,
+        )
+
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        se, so = p.communicate()
+        print(so)
+        print(se)
+
+        dstfp = os.path.join(self.dstdirrgb, 'WV02_20110901210502_103001000D52C800_11SEP01210502-M1BS-052560788010_01_P008_u08rf3413_pansh.tif')
+        dstfp_xml = os.path.join(self.dstdirrgb, 'WV02_20110901210502_103001000D52C800_11SEP01210502-M1BS-052560788010_01_P008_u08rf3413_pansh.xml')
+
+        self.assertTrue(os.path.isfile(dstfp))
+        self.assertTrue(os.path.isfile(dstfp_xml))
+
+        with gdal.Open(dstfp, gdalconst.GA_ReadOnly) as ds:
+            self.assertTrue(ds.RasterCount == 3)
 
 
     def tearDown(self):


### PR DESCRIPTION
bug fix to address incorrect weights for RGB and BGRN pansharpening jobs. input for checking band counts to accurately set weights now points to input multispectral ortho instead of input multispectral raw image. 