### PR TITLE
Handle XML namespaces from Vantor imagery

### DIFF
--- a/lib/mosaic.py
+++ b/lib/mosaic.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import requests
 from datetime import datetime, timedelta
-from xml.etree import cElementTree as ET
+from xml.etree import ElementTree as ET
 
 import numpy
 from numpy import flatnonzero

--- a/lib/ortho_functions.py
+++ b/lib/ortho_functions.py
@@ -11,7 +11,7 @@ import tarfile
 import configparser
 from datetime import datetime
 from xml.dom import minidom
-from xml.etree import cElementTree as ET
+from xml.etree import ElementTree as ET
 
 from osgeo import gdal, gdalconst, ogr, osr
 
@@ -1671,8 +1671,20 @@ def write_output_metadata(args, info):
 
     #  If DG
     if info.vendor == Vendor.DG:
-        imd = info.metad_etree.find("IMD")
-        til = info.metad_etree.find("TIL")
+
+        def strip_ns(element):
+            if element.tag.startswith("{"):
+                element.tag = element.tag.split("}", 1)[1]
+
+            for child in element:
+                strip_ns(child)
+
+        imd = info.metad_etree.find("{*}IMD")
+        if imd is not None:
+            strip_ns(imd)
+        til = info.metad_etree.find("{*}TIL")
+        if til is not None:
+            strip_ns(til)
 
     #  If GE
     elif info.vendor == Vendor.GE and info.sat == "GE01":
@@ -2184,26 +2196,26 @@ def get_dg_calib_dict(metad_etree, stretch):
 
     calibDict = {}
     abscalfact_dict = {}
-    nodeIMD = metad_etree.find('IMD')
+    nodeIMD = metad_etree.find('{*}IMD')
     if nodeIMD is None:
         raise utils.InvalidMetadataError(f"Metadata file is missing the IMD xml section")
     else:
-        nodeIMAGE = nodeIMD.find('IMAGE')
-        nodeMPP = nodeIMD.find('MAP_PROJECTED_PRODUCT')
+        nodeIMAGE = nodeIMD.find('{*}IMAGE')
+        nodeMPP = nodeIMD.find('{*}MAP_PROJECTED_PRODUCT')
 
-        sat = nodeIMAGE.find('SATID').text
-        elem = nodeIMAGE.find('FIRSTLINETIME')
+        sat = nodeIMAGE.find('{*}SATID').text
+        elem = nodeIMAGE.find('{*}FIRSTLINETIME')
         if elem is None:
             if nodeMPP is not None:
-                elem = nodeMPP.find('EARLIESTACQTIME')
+                elem = nodeMPP.find('{*}EARLIESTACQTIME')
         if elem is not None:
             t = elem.text
         else:
             raise utils.InvalidMetadataError(f"Metadata file is missing the FIRSTLINETIME and EARLIESTACQTIME xml tags")
 
-        elem = nodeIMAGE.find('MEANSUNEL')
+        elem = nodeIMAGE.find('{*}MEANSUNEL')
         if elem is None:
-            elem = nodeIMAGE.find('SUNEL')
+            elem = nodeIMAGE.find('{*}SUNEL')
         if elem is not None:
             sunEl = float(elem.text)
         else:
@@ -2217,9 +2229,9 @@ def get_dg_calib_dict(metad_etree, stretch):
 
         # get BAND tags
         for band in DGbandList:
-            nodeBAND = nodeIMD.find(band)
+            nodeBAND = nodeIMD.find("{*}" + f"{band}")
             if nodeBAND is not None:
-                elem = nodeBAND.find('ABSCALFACTOR')
+                elem = nodeBAND.find('{*}ABSCALFACTOR')
                 if elem is not None:
                     abscal = float(elem.text)
                     if abscal < 0:
@@ -2229,7 +2241,7 @@ def get_dg_calib_dict(metad_etree, stretch):
                     raise utils.InvalidMetadataError(
                         f"Metadata file is missing the ABSCALFACTOR xml tag")
 
-                elem = nodeBAND.find('EFFECTIVEBANDWIDTH')
+                elem = nodeBAND.find('{*}EFFECTIVEBANDWIDTH')
                 if elem is not None:
                     effbandw = float(elem.text)
                 else:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 from datetime import datetime
 from io import StringIO
-from xml.etree import cElementTree as ET
+from xml.etree import ElementTree as ET
 
 import numpy as np
 from osgeo import gdal, ogr, osr

--- a/pgc_ortho.py
+++ b/pgc_ortho.py
@@ -4,10 +4,8 @@ from __future__ import division
 
 import argparse
 import logging
-import math
 import os
 import sys
-import xml.etree.ElementTree as ET
 import datetime
 
 import numpy as np

--- a/tests/test_mosaic_lib.py
+++ b/tests/test_mosaic_lib.py
@@ -271,6 +271,28 @@ class TestMosaicImageInfo(unittest.TestCase):
             self.assertAlmostEqual(image_info.stat_dct[1][i], stat_dct[1][i])
         self.assertEqual(image_info.datapixelcount_dct, datapixelcount_dct)
 
+    def test_image_info_new_vantor_metadata(self):
+        image = "WV02_20210313084410_10300100BB7B2D00_21MAR13084410-M1BS-600000003955_01_P002_u08rf32635.tif"
+        image_info = mosaic.ImageInfo(os.path.join(self.srcdir, image), "IMAGE")
+
+        self.assertEqual(image_info.xres, 100)
+        self.assertEqual(image_info.yres, 100)
+        self.assertEqual(image_info.bands, 8)
+        self.assertEqual(image_info.datatype, 1)
+
+        mosaic_args = MosaicArgs()
+        mosaic_params = mosaic.getMosaicParameters(image_info, mosaic_args)
+        image_info.getScore(mosaic_params)
+
+        self.assertEqual(image_info.sensor, "WV02")
+        self.assertEqual(image_info.sunel, 66.0)
+        self.assertEqual(image_info.ona, 22.9)
+        self.assertEqual(image_info.cloudcover, 0.192)
+        self.assertEqual(image_info.panfactor, 1)
+        self.assertEqual(image_info.date_diff, -9999)
+        self.assertEqual(image_info.year_diff, -9999)
+        self.assertAlmostEqual(image_info.score, 77.2106667,6)
+
     def test_filter_images(self):
         image_list = glob.glob(os.path.join(self.srcdir, '*.tif'))
         imginfo_list = [mosaic.ImageInfo(image, "IMAGE") for image in image_list]

--- a/tests/test_ortho.py
+++ b/tests/test_ortho.py
@@ -53,6 +53,7 @@ class TestOrthoFunc(unittest.TestCase):
             ('WV03_20140919212947_104001000227BF00_14SEP19212947-M1BS-500191821040_01_P002.ntf', 3413, True),
             ('WV03_20190114103353_104C0100462B2500_19JAN14103353-C1BA-502817502010_01_P001.ntf', 3031, True),
             ('LG01_20250812153720_B110001102369000_25AUG12153720-M1BS-050463930010_01_P001.tif', 32619, True),
+            ('WV02_20210313084410_10300100BB7B2D00_21MAR13084410-M1BS-600000003955_01_P002.ntf', 32635, True),
         ]
         
         for test_image, epsg, result in test_images:
@@ -61,8 +62,7 @@ class TestOrthoFunc(unittest.TestCase):
             dstfp = os.path.join(self.dstdir, '{}_u08rf{}.tif'.format(
                 os.path.splitext(test_image)[0], epsg))
             print(srcfp)
-            cmd = r"""python "{}" -r 10 -p {} "{}" "{}" """.format(
-                self.scriptpath, epsg, srcfp, self.dstdir)
+            cmd = f'python "{self.scriptpath}" -r 100 -p {epsg} "{srcfp}" "{self.dstdir}" '
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             se, so = p.communicate()
             # print(so)

--- a/tests/test_ortho_functions.py
+++ b/tests/test_ortho_functions.py
@@ -53,6 +53,7 @@ class TestReadMetadata(unittest.TestCase):
             ('WV03_20190114103355_104C0100462B2500_19JAN14103355-C1BB-502817502010_01_P001.xml', True, True), # CAVIS B
             ('LG01_20250812153720_B110001102369000_25AUG12153720-M1BS-050463930010_01_P001.xml', True, True), # Legion 1
             ('LG02_20240927155103_B12000110059ED00_24SEP27155103-M2AS-200006033301_01_P001.xml', True, False), # Legion 2, invalid calibration
+            ('WV02_20210313084410_10300100BB7B2D00_21MAR13084410-M1BS-600000003955_01_P002.xml', True, True), # Vantor XML with Namespaces
         )
 
         dg_valid_data_range = {


### PR DESCRIPTION
This PR handles searching new-style Vantor XMLs with namespaces while preserving backward compatibility.  Namespaces are stripped before the XML info is reused in ortho product metadata.